### PR TITLE
Slimmer image

### DIFF
--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -5,9 +5,9 @@ MAINTAINER Odoo S.A. <info@odoo.com>
 RUN set -x; \
         apt-get update \
         && apt-get install -y --no-install-recommends \
-            adduser \
             ca-certificates \
             curl \
+            nodejs \
             npm \
             python-support \
             python-pyinotify \
@@ -17,6 +17,7 @@ RUN set -x; \
         && echo '40e8b906de658a2221b15e4e8cd82565a47d7ee8 wkhtmltox.deb' | sha1sum -c - \
         && dpkg --force-depends -i wkhtmltox.deb \
         && apt-get -y install -f --no-install-recommends \
+        && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false -o APT::AutoRemove::SuggestsImportant=false npm \
         && rm -rf /var/lib/apt/lists/* wkhtmltox.deb
 
 # Install Odoo

--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Odoo S.A. <info@odoo.com>
 # Install some deps, lessc and less-plugin-clean-css, and wkhtmltopdf
 RUN set -x; \
         apt-get update \
-        && apt-get install -y \
+        && apt-get install -y --no-install-recommends \
             adduser \
             ca-certificates \
             curl \
@@ -16,7 +16,7 @@ RUN set -x; \
         && curl -o wkhtmltox.deb -SL http://nightly.odoo.com/extra/wkhtmltox-0.12.1.2_linux-jessie-amd64.deb \
         && echo '40e8b906de658a2221b15e4e8cd82565a47d7ee8 wkhtmltox.deb' | sha1sum -c - \
         && dpkg --force-depends -i wkhtmltox.deb \
-        && apt-get -y install -f \
+        && apt-get -y install -f --no-install-recommends \
         && rm -rf /var/lib/apt/lists/* wkhtmltox.deb
 
 # Install Odoo


### PR DESCRIPTION
I was interested in trying out the `odoo` image today and found that it weighs in at almost a gigabyte!

I went through the Dockerfile and the resulting image and made a few changes that resulted in the image dropping from 914+ megabytes to svelte 750 megabytes (ahem):

```
REPOSITORY          TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
odoo                diet                0ec6ca044a82        18 minutes ago      750.2 MB
odoo                latest              003d65c3385f        3 days ago          914.5 MB
```

Much of the remaining bulk is coming from the two deb packages that get installed, `wkhtmltox` and `odoo`.

In the case of `wkhtmltox`, it's a 121 megabyte package and contains these three beasts:
```
  3124 38760 -rwxr-xr-x   1 root     root     39689480 Feb 27 14:49 ./usr/local/bin/wkhtmltoimage
  3126 38844 -rwxr-xr-x   1 root     root     39773192 Feb 27 14:49 ./usr/local/bin/wkhtmltopdf
  3127 43980 -rwxr-xr-x   1 root     root     45034680 Feb 27 14:49 ./usr/local/lib/libwkhtmltox.so.0.12.1
```

Since you guys appear to be using only the `wkhtmltopdf` binary itself and it is not dynamically linked to `libwkhtmltox.so.0.12.1`, perhaps it would be possible to cut out another 80 megabytes by just including or building the static binary you need in this image.

The `odoo` package itself seems to get most of its 293 megabytes from the fact that a whole bunch of addons are included, along with all of their `*.po` translations. Not sure if you guys have more targeted `*.deb` packages available, but it would be nice to take an approach where there is an `odoo` metapackage that pulls in a bunch of smaller `odoo-*` packages to allow for a smaller installation based on the Debian packages.