### PR TITLE
Allow PG* env vars to be set directly

### DIFF
--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -38,8 +38,11 @@ VOLUME ["/var/lib/odoo", "/mnt/extra-addons"]
 # Expose Odoo services
 EXPOSE 8069 8071
 
+# Set the default config file
+ENV OPENERP_SERVER /etc/odoo/openerp-server.conf
+
 # Set default user when running the container
 USER odoo
 
 ENTRYPOINT ["/entrypoint.sh"]
-CMD ["/usr/bin/openerp-server", "--config=/etc/odoo/openerp-server.conf"]
+CMD ["openerp-server"]

--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -27,8 +27,8 @@ RUN curl -o odoo.deb -SL http://nightly.odoo.com/${ODOO_VERSION}/nightly/deb/odo
         && apt-get -y install -f --no-install-recommends \
         && rm -rf /var/lib/apt/lists/* odoo.deb
 
-# Copy run script and Odoo configuration file
-COPY ./run.sh /
+# Copy entrypoint script and Odoo configuration file
+COPY ./entrypoint.sh /
 COPY ./openerp-server.conf /etc/odoo/
 RUN chown odoo /etc/odoo/openerp-server.conf
 
@@ -41,4 +41,5 @@ EXPOSE 8069 8071
 # Set default user when running the container
 USER odoo
 
-ENTRYPOINT ["/run.sh"]
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["/usr/bin/openerp-server", "--config=/etc/odoo/openerp-server.conf"]

--- a/8.0/entrypoint.sh
+++ b/8.0/entrypoint.sh
@@ -9,4 +9,8 @@ set -e
 : ${PGPASSWORD:=$DB_ENV_POSTGRES_PASSWORD}
 export PGHOST PGPORT PGUSER PGPASSWORD
 
+if [ "${1:0:1}" = '-' ]; then
+	set -- /usr/bin/openerp-server --config=/etc/odoo/openerp-server.conf "$@"
+fi
+
 exec "$@"

--- a/8.0/entrypoint.sh
+++ b/8.0/entrypoint.sh
@@ -9,6 +9,7 @@ set -e
 : ${PGPASSWORD:=$DB_ENV_POSTGRES_PASSWORD}
 export PGHOST PGPORT PGUSER PGPASSWORD
 
+# if the first arg starts with '-', prepend 'openerp-server' to $@
 if [ "${1:0:1}" = '-' ]; then
 	set -- openerp-server "$@"
 fi

--- a/8.0/entrypoint.sh
+++ b/8.0/entrypoint.sh
@@ -10,7 +10,7 @@ set -e
 export PGHOST PGPORT PGUSER PGPASSWORD
 
 if [ "${1:0:1}" = '-' ]; then
-	set -- /usr/bin/openerp-server --config=/etc/odoo/openerp-server.conf "$@"
+	set -- openerp-server "$@"
 fi
 
 exec "$@"

--- a/8.0/entrypoint.sh
+++ b/8.0/entrypoint.sh
@@ -9,7 +9,4 @@ set -e
 : ${PGPASSWORD:=$DB_ENV_POSTGRES_PASSWORD}
 export PGHOST PGPORT PGUSER PGPASSWORD
 
-[ "$1" != "--" ] && exec "$@"
-
-shift
-exec /usr/bin/openerp-server --config=/etc/odoo/openerp-server.conf "$@"
+exec "$@"

--- a/8.0/entrypoint.sh
+++ b/8.0/entrypoint.sh
@@ -11,6 +11,11 @@ export PGHOST PGPORT PGUSER PGPASSWORD
 
 # if the first arg starts with '-', prepend 'openerp-server' to $@
 if [ "${1:0:1}" = '-' ]; then
+	# drop the first arg if it is '--'
+	if [ "$1" = '--' ]; then
+		shift
+	fi
+
 	set -- openerp-server "$@"
 fi
 

--- a/8.0/run.sh
+++ b/8.0/run.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
 
+set -e
+
 # set odoo database host, port, user and password
-export PGHOST=$DB_PORT_5432_TCP_ADDR
-export PGPORT=$DB_PORT_5432_TCP_PORT
-export PGUSER=$DB_ENV_POSTGRES_USER
-export PGPASSWORD=$DB_ENV_POSTGRES_PASSWORD
+: ${PGHOST:=$DB_PORT_5432_TCP_ADDR}
+: ${PGPORT:=$DB_PORT_5432_TCP_PORT}
+: ${PGUSER:=${DB_ENV_POSTGRES_USER:='postgres'}}
+: ${PGPASSWORD:=$DB_ENV_POSTGRES_PASSWORD}
+export PGHOST PGPORT PGUSER PGPASSWORD
 
 [ "$1" != "--" ] && exec "$@"
 


### PR DESCRIPTION
Makes it possible to use a non-linked Postgres container without having to fake `$DB_*` environment variables.