### PR TITLE
Install low-level renderpm for barcodes

### DIFF
--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -11,6 +11,7 @@ RUN set -x; \
             npm \
             python-support \
             python-pyinotify \
+            python-renderpm \
         && npm install -g less less-plugin-clean-css \
         && ln -s /usr/bin/nodejs /usr/bin/node \
         && curl -o wkhtmltox.deb -SL http://nightly.odoo.com/extra/wkhtmltox-0.12.1.2_linux-jessie-amd64.deb \


### PR DESCRIPTION
Odoo deb package has no dependency on python-renderpm which is needed by python-reportlab to support printing barcodes!