### PR TITLE
Update Odoo Docker to latest version

### DIFF
--- a/9.0/Dockerfile
+++ b/9.0/Dockerfile
@@ -20,10 +20,11 @@ RUN set -x; \
         && rm -rf /var/lib/apt/lists/* wkhtmltox.deb
 
 # Install Odoo
-ENV ODOO_VERSION 9.0c
+ENV ODOO_VERSION 9.0
+ENV ODOO_MINOR_VERSION 9.0c
 ENV ODOO_RELEASE 20151209
 RUN set -x; \
-        curl -o odoo.deb -SL http://nightly.odoo.com/${ODOO_VERSION}/nightly/deb/odoo_${ODOO_VERSION}.${ODOO_RELEASE}_all.deb \
+        curl -o odoo.deb -SL http://nightly.odoo.com/${ODOO_VERSION}/nightly/deb/odoo_${ODOO_MINOR_VERSION}.${ODOO_RELEASE}_all.deb \
         && dpkg --force-depends -i odoo.deb \
         && apt-get update \
         && apt-get -y install -f --no-install-recommends \

--- a/9.0/Dockerfile
+++ b/9.0/Dockerfile
@@ -20,8 +20,8 @@ RUN set -x; \
         && rm -rf /var/lib/apt/lists/* wkhtmltox.deb
 
 # Install Odoo
-ENV ODOO_VERSION 9.0
-ENV ODOO_RELEASE 20151008
+ENV ODOO_VERSION 9.0c
+ENV ODOO_RELEASE 20151209
 RUN set -x; \
         curl -o odoo.deb -SL http://nightly.odoo.com/${ODOO_VERSION}/nightly/deb/odoo_${ODOO_VERSION}.${ODOO_RELEASE}_all.deb \
         && dpkg --force-depends -i odoo.deb \


### PR DESCRIPTION
Update Dockerfile to use latest versions of Odoo, as of 2015-12-09.

This fixes https://github.com/odoo/docker/issues/44

Related to https://github.com/odoo/odoo/issues/9826

And includes the changes mentioned in: https://github.com/odoo/odoo/commit/0ee11f23f15ab11851baf3ca00d9c3a5947fe294