### PR TITLE
Switch to ubuntu:15.10 and add gevent dependencies

### DIFF
--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM ubuntu:15.10
 MAINTAINER Odoo S.A. <info@odoo.com>
 
 # Install some deps, lessc and less-plugin-clean-css, and wkhtmltopdf
@@ -12,6 +12,9 @@ RUN set -x; \
             python-pyinotify \
             python-renderpm \
             python-support \
+            python-gevent \
+            python-psycopg2 \
+            python-psycogreen \
         && curl -o wkhtmltox.deb -SL http://nightly.odoo.com/extra/wkhtmltox-0.12.1.2_linux-jessie-amd64.deb \
         && echo '40e8b906de658a2221b15e4e8cd82565a47d7ee8 wkhtmltox.deb' | sha1sum -c - \
         && dpkg --force-depends -i wkhtmltox.deb \


### PR DESCRIPTION
I would get an import gevent.monkey error when I was launching the docker image with workers > 0
Switching to ubuntu 15.10 was necessary because it had the python-psycogreen package

debian:jessie -> no package available
ubuntu:14.04 -> no package available

