### PR TITLE
Added Docker healthcheck for /10.0

### DIFF
--- a/10.0/Dockerfile
+++ b/10.0/Dockerfile
@@ -42,6 +42,9 @@ RUN mkdir -p /mnt/extra-addons \
         && chown -R odoo /mnt/extra-addons
 VOLUME ["/var/lib/odoo", "/mnt/extra-addons"]
 
+# the Docker healthcheck command
+HEALTHCHECK CMD curl --fail http://localhost:8069/web/database/selector || exit 1
+
 # Expose Odoo services
 EXPOSE 8069 8071
 


### PR DESCRIPTION
Explanation:
Added Docker `HEALTHCHECK` command. Pointing to `/web/database/selector` for the health check because it is the first functional thing that should work and be available for a typical install. For custom deployments where admins wish to disable access to `/web/database/selector` they could use a different URL, or they could just prevent access to that path at the proxy server, in which case nothing changes in within the Docker environment for this to work. (See Docker's [HEALTHCHECK](https://docs.docker.com/engine/reference/builder/#healthcheck) documentation for more)

Purpose:
Provide rudimentary Odoo server state info to Docker service so that Docker knows if the service in the container is healthy or not. Contributes to monitoring and swarm management.