### PR TITLE
[10.0] add python-xlrd packadge need to import xls & xlsx file

### DIFF
--- a/10.0/Dockerfile
+++ b/10.0/Dockerfile
@@ -12,6 +12,7 @@ RUN set -x; \
             python-pip \
             python-renderpm \
             python-support \
+            python-xlrd \
             python-watchdog \
         && curl -o wkhtmltox.deb -SL http://nightly.odoo.com/extra/wkhtmltox-0.12.1.2_linux-jessie-amd64.deb \
         && echo '40e8b906de658a2221b15e4e8cd82565a47d7ee8 wkhtmltox.deb' | sha1sum -c - \


### PR DESCRIPTION
unless only csv files supported 