### PR TITLE
add python3-watchdog dependency to 11.0

### DIFF
--- a/11.0/Dockerfile
+++ b/11.0/Dockerfile
@@ -16,6 +16,7 @@ RUN set -x; \
             python3-renderpm \
             libssl1.0-dev \
             xz-utils \
+            python3-watchdog \
         && curl -o wkhtmltox.tar.xz -SL https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.4/wkhtmltox-0.12.4_linux-generic-amd64.tar.xz \
         && echo '3f923f425d345940089e44c1466f6408b9619562 wkhtmltox.tar.xz' | sha1sum -c - \
         && tar xvf wkhtmltox.tar.xz \


### PR DESCRIPTION
Just added a python3-watchdog as dependency because I want to use the --dev=reload feature, which does not work without it.

See also issue odoo/odoo#21178 which should probably be fixed first.