### PR TITLE
commented ldap support on Dockerfile

### DIFF
--- a/10.0/Dockerfile
+++ b/10.0/Dockerfile
@@ -20,6 +20,13 @@ RUN set -x; \
         && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false -o APT::AutoRemove::SuggestsImportant=false npm \
         && rm -rf /var/lib/apt/lists/* wkhtmltox.deb \
         && pip install psycogreen==1.0
+	
+## Uncomment this lines to add ldap auth support 
+#RUN set -x; \
+#    	 apt-get install -y --no-install-recommends \
+#	     python-dev gcc libldap2-dev libssl-dev ; \
+#	 pip install pyldap    
+	
 
 # Install Odoo
 ENV ODOO_VERSION 10.0

--- a/11.0/Dockerfile
+++ b/11.0/Dockerfile
@@ -23,6 +23,13 @@ RUN set -x; \
         && cp wkhtmltox/bin/* /usr/local/bin/ \
         && cp -r wkhtmltox/share/man/man1 /usr/local/share/man/
 
+
+## Uncomment this lines to add ldap auth support 
+#RUN set -x; \
+#    	 apt-get install -y --no-install-recommends \
+#	     python3-dev gcc libldap2-dev libssl-dev ; \
+#	 pip3 install pyldap    
+
 # Install Odoo
 ENV ODOO_VERSION 11.0
 ENV ODOO_RELEASE 20171030

--- a/9.0/Dockerfile
+++ b/9.0/Dockerfile
@@ -21,6 +21,13 @@ RUN set -x; \
         && rm -rf /var/lib/apt/lists/* wkhtmltox.deb \
         && pip install psycogreen==1.0
 
+## Uncomment this lines to add ldap auth support 
+#RUN set -x; \
+#    	 apt-get install -y --no-install-recommends \
+#	     python-dev gcc libldap2-dev libssl-dev ; \
+#	 pip install pyldap    
+
+
 # Install Odoo
 ENV ODOO_VERSION 9.0
 ENV ODOO_RELEASE 20171030


### PR DESCRIPTION
Odoo have support to ldap authentication, but the actual image dont have ldap libraries.
The commented lines add ldap support.
Maybe you can uncomment this lines and add support for ldap on native docker image.

Thanks for your job
```
## Uncomment this lines to add ldap auth support
#RUN set -x; \
#        apt-get install -y --no-install-recommends \
#            python3-dev gcc libldap2-dev libssl-dev ; \
#        pip3 install pyldap
```