### PR TITLE
[FIX] excel export on interactive tables require "xlwt".

### DIFF
--- a/11.0/Dockerfile
+++ b/11.0/Dockerfile
@@ -35,7 +35,7 @@ RUN set -x; \
         && rm -rf /var/lib/apt/lists/* odoo.deb
 
 # Copy entrypoint script and Odoo configuration file
-RUN pip3 install num2words
+RUN pip3 install num2words xlwt
 COPY ./entrypoint.sh /
 COPY ./odoo.conf /etc/odoo/
 RUN chown odoo /etc/odoo/odoo.conf


### PR DESCRIPTION
This fixes: https://github.com/odoo/docker/issues/161
