### PR TITLE
Added phonenumbers python package and replaced deprecated MAINTAINER

### DIFF
--- a/10.0/Dockerfile
+++ b/10.0/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:jessie
-MAINTAINER Odoo S.A. <info@odoo.com>
+LABEL maintainer="Odoo S.A. <info@odoo.com>"
 
 # Install some deps, lessc and less-plugin-clean-css, and wkhtmltopdf
 RUN set -x; \

--- a/11.0/Dockerfile
+++ b/11.0/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:stretch
-MAINTAINER Odoo S.A. <info@odoo.com>
+LABEL maintainer="Odoo S.A. <info@odoo.com>"
 
 # Generate locale C.UTF-8 for postgres and general locale data
 ENV LANG C.UTF-8
@@ -35,7 +35,7 @@ RUN set -x; \
         && rm -rf /var/lib/apt/lists/* odoo.deb
 
 # Copy entrypoint script and Odoo configuration file
-RUN pip3 install num2words xlwt
+RUN pip3 install num2words xlwt phonenumbers
 COPY ./entrypoint.sh /
 COPY ./odoo.conf /etc/odoo/
 RUN chown odoo /etc/odoo/odoo.conf

--- a/9.0/Dockerfile
+++ b/9.0/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:jessie
-MAINTAINER Odoo S.A. <info@odoo.com>
+LABEL maintainer="Odoo S.A. <info@odoo.com>"
 
 # Install some deps, lessc and less-plugin-clean-css, and wkhtmltopdf
 RUN set -x; \


### PR DESCRIPTION
Maintainer has been deprecated, so I replaced it with the correct label:
https://docs.docker.com/engine/reference/builder/#maintainer-deprecated

Further the "phone validation addon" has a dependency to phonenumbers (optional I know) but still it would be good to have all optional packages included in order to have all the features available.