### PR TITLE
chmod entrypoint.sh to make it executable

### DIFF
--- a/9.0/Dockerfile
+++ b/9.0/Dockerfile
@@ -34,6 +34,7 @@ RUN set -x; \
 
 # Copy entrypoint script and Odoo configuration file
 COPY ./entrypoint.sh /
+RUN chmod 755 /entrypoint.sh
 COPY ./openerp-server.conf /etc/odoo/
 RUN chown odoo /etc/odoo/openerp-server.conf
 


### PR DESCRIPTION
Did this in order to avoid the following error from appears when the "entrypoint.sh" file has not set the executable attributes.

Error that appears if entrypoint.sh is not executable:
docker: Error response from daemon: OCI runtime create failed: container_linux.go:296: starting container process caused "exec: \"/entrypoint.sh\": permission denied": unknown.