### PR TITLE
Add 'noto-fonts' to the apt dependencies

### DIFF
--- a/10.0/Dockerfile
+++ b/10.0/Dockerfile
@@ -3,9 +3,10 @@ MAINTAINER Odoo S.A. <info@odoo.com>
 
 # Install some deps, lessc and less-plugin-clean-css, and wkhtmltopdf
 RUN set -x; \
-        apt-get update \
+        apt-get update --fix-missing \
         && apt-get install -y --no-install-recommends \
             ca-certificates \
+            fonts-noto \
             curl \
             node-less \
             python-gevent \

--- a/11.0/Dockerfile
+++ b/11.0/Dockerfile
@@ -6,9 +6,10 @@ ENV LANG C.UTF-8
 
 # Install some deps, lessc and less-plugin-clean-css, and wkhtmltopdf
 RUN set -x; \
-        apt-get update \
+        apt-get update --fix-missing \
         && apt-get install -y --no-install-recommends \
             ca-certificates \
+            fonts-noto \
             curl \
             node-less \
             python3-pip \

--- a/9.0/Dockerfile
+++ b/9.0/Dockerfile
@@ -3,9 +3,10 @@ MAINTAINER Odoo S.A. <info@odoo.com>
 
 # Install some deps, lessc and less-plugin-clean-css, and wkhtmltopdf
 RUN set -x; \
-        apt-get update \
+        apt-get update --fix-missing \
         && apt-get install -y --no-install-recommends \
             ca-certificates \
+            fonts-noto \
             curl \
             node-less \
             python-gevent \


### PR DESCRIPTION
Since some non-latin fonts are not installed, some text is not rendered by wkhtmlpdf correctly.
So, I just add "noto-fonts" to the apt-get dependencies which is developed by Google.

The designe of "Google Noto Fonts" is aimed to support all languages with a harmonious look and feel.
**FYI** https://www.google.com/get/noto/

I think this patch will also fix #122 though i'm not tested in Chinese (Because I'm Japanese).