### PR TITLE
Expose longpolling port 8072 (refs #107)

### DIFF
--- a/10.0/Dockerfile
+++ b/10.0/Dockerfile
@@ -43,7 +43,7 @@ RUN mkdir -p /mnt/extra-addons \
 VOLUME ["/var/lib/odoo", "/mnt/extra-addons"]
 
 # Expose Odoo services
-EXPOSE 8069 8071
+EXPOSE 8069 8071 8072
 
 # Set the default config file
 ENV ODOO_RC /etc/odoo/odoo.conf

--- a/11.0/Dockerfile
+++ b/11.0/Dockerfile
@@ -46,7 +46,7 @@ RUN mkdir -p /mnt/extra-addons \
 VOLUME ["/var/lib/odoo", "/mnt/extra-addons"]
 
 # Expose Odoo services
-EXPOSE 8069 8071
+EXPOSE 8069 8071 8072
 
 # Set the default config file
 ENV ODOO_RC /etc/odoo/odoo.conf

--- a/9.0/Dockerfile
+++ b/9.0/Dockerfile
@@ -43,7 +43,7 @@ RUN mkdir -p /mnt/extra-addons \
 VOLUME ["/var/lib/odoo", "/mnt/extra-addons"]
 
 # Expose Odoo services
-EXPOSE 8069 8071
+EXPOSE 8069 8071 8072
 
 # Set the default config file
 ENV OPENERP_SERVER /etc/odoo/openerp-server.conf


### PR DESCRIPTION
Currently, the image exposes the HTTP port (8069) and the XMLRPC port (8071), but does not expose the longpolling port (8072), which is necessary for normal operation and to avoid a deluge of errors in the webserver logs.