### PR TITLE
[IMP] Odoo 11.0: add python3-pyldap dependency

### DIFF
--- a/11.0/Dockerfile
+++ b/11.0/Dockerfile
@@ -17,6 +17,7 @@ RUN set -x; \
             libssl1.0-dev \
             xz-utils \
             python3-watchdog \
+            python3-pyldap \
         && curl -o wkhtmltox.tar.xz -SL https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.4/wkhtmltox-0.12.4_linux-generic-amd64.tar.xz \
         && echo '3f923f425d345940089e44c1466f6408b9619562 wkhtmltox.tar.xz' | sha1sum -c - \
         && tar xvf wkhtmltox.tar.xz \


### PR DESCRIPTION
pyldap is needed for `Authentication via LDAP` plugin.
Installing with apt results in slimmer image
(comparing to pip approach).

Fixes: odoo/docker#140