### PR TITLE
[12.0] Add postgresql 10 client to DockerFile

### DIFF
--- a/12.0/Dockerfile
+++ b/12.0/Dockerfile
@@ -10,6 +10,7 @@ RUN set -x; \
         && apt-get install -y --no-install-recommends \
             ca-certificates \
             curl \
+			gnupg \
             libssl1.0-dev \
             node-less \
             python3-pip \
@@ -25,6 +26,13 @@ RUN set -x; \
         && dpkg --force-depends -i wkhtmltox.deb\
         && apt-get -y install -f --no-install-recommends \
         && rm -rf /var/lib/apt/lists/* wkhtmltox.deb
+
+# Install Postgresql cli V10
+RUN set -x; \
+		echo "deb [arch=amd64] http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
+		&& curl -sSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
+		&& apt-get update \
+		&& apt-get install -y postgresql-client-10
 
 # Install Odoo
 ENV ODOO_VERSION 12.0


### PR DESCRIPTION
The default installed pg version is 9.6 that is incompatible with pg v10
See #234 issue