### PR TITLE
[IMP] Odoo-11.0: add `python3-xlrd` for excel import

### DIFF
--- a/11.0/Dockerfile
+++ b/11.0/Dockerfile
@@ -28,6 +28,7 @@ RUN set -x; \
             python3-vobject \
             python3-watchdog \
             python3-xlwt \
+            python3-xlrd \
             xz-utils \
         && curl -o wkhtmltox.deb -sSL https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.stretch_amd64.deb \
         && echo '7e35a63f9db14f93ec7feeb0fce76b30c08f2057 wkhtmltox.deb' | sha1sum -c - \


### PR DESCRIPTION
Importing Excel files is a built-in feature that's needed by all of our projects.

Is there a problem to be included by default in the official Docker image?