### PR TITLE
[FIX] Odoo 11.0-13.0: get database config value

### DIFF
--- a/11.0/entrypoint.sh
+++ b/11.0/entrypoint.sh
@@ -12,11 +12,12 @@ set -e
 DB_ARGS=()
 function check_config() {
     param="$1"
-    value="$2"
-    if ! grep -q -E "^\s*\b${param}\b\s*=" "$ODOO_RC" ; then
-        DB_ARGS+=("--${param}")
-        DB_ARGS+=("${value}")
-   fi;
+    value="$2"    
+    if grep -q -E "^\s*\b${param}\b\s*=" "$ODOO_RC" ; then       
+        value=$(grep -E "^\s*\b${param}\b\s*=" "$ODOO_RC" |cut -d " " -f3|sed 's/["\n\r]//g')
+    fi;
+    DB_ARGS+=("--${param}")
+    DB_ARGS+=("${value}")
 }
 check_config "db_host" "$HOST"
 check_config "db_port" "$PORT"

--- a/12.0/entrypoint.sh
+++ b/12.0/entrypoint.sh
@@ -13,10 +13,11 @@ DB_ARGS=()
 function check_config() {
     param="$1"
     value="$2"
-    if ! grep -q -E "^\s*\b${param}\b\s*=" "$ODOO_RC" ; then
-        DB_ARGS+=("--${param}")
-        DB_ARGS+=("${value}")
-   fi;
+    if grep -q -E "^\s*\b${param}\b\s*=" "$ODOO_RC" ; then       
+        value=$(grep -E "^\s*\b${param}\b\s*=" "$ODOO_RC" |cut -d " " -f3|sed 's/["\n\r]//g')
+    fi;
+    DB_ARGS+=("--${param}")
+    DB_ARGS+=("${value}")
 }
 check_config "db_host" "$HOST"
 check_config "db_port" "$PORT"

--- a/13.0/entrypoint.sh
+++ b/13.0/entrypoint.sh
@@ -13,10 +13,11 @@ DB_ARGS=()
 function check_config() {
     param="$1"
     value="$2"
-    if ! grep -q -E "^\s*\b${param}\b\s*=" "$ODOO_RC" ; then
-        DB_ARGS+=("--${param}")
-        DB_ARGS+=("${value}")
-   fi;
+    if grep -q -E "^\s*\b${param}\b\s*=" "$ODOO_RC" ; then       
+        value=$(grep -E "^\s*\b${param}\b\s*=" "$ODOO_RC" |cut -d " " -f3|sed 's/["\n\r]//g')
+    fi;
+    DB_ARGS+=("--${param}")
+    DB_ARGS+=("${value}")
 }
 check_config "db_host" "$HOST"
 check_config "db_port" "$PORT"


### PR DESCRIPTION
when running the docker wil got error if we have a configuration database in the config file. The arguments for the wait-for-psql.py script are only formed when configuration database in the config file do not exist.

with this commit, it will get the configuration database in the config file (if it exists) and get it in env (if it does not exist)