### PR TITLE
fixed Dockerfiles

### DIFF
--- a/11.0/Dockerfile
+++ b/11.0/Dockerfile
@@ -55,9 +55,8 @@ ARG ODOO_RELEASE=20200121
 ARG ODOO_SHA=13f30434cb4fb28b11d78fd4e7c616d03362f779
 RUN curl -o odoo.deb -sSL http://nightly.odoo.com/${ODOO_VERSION}/nightly/deb/odoo_${ODOO_VERSION}.${ODOO_RELEASE}_all.deb \
         && echo "${ODOO_SHA} odoo.deb" | sha1sum -c - \
-        && dpkg --force-depends -i odoo.deb \
         && apt-get update \
-        && apt-get -y install -f --no-install-recommends \
+        && apt-get -y install --no-install-recommends ./odoo.deb\
         && rm -rf /var/lib/apt/lists/* odoo.deb
 
 # Copy entrypoint script and Odoo configuration file

--- a/11.0/Dockerfile
+++ b/11.0/Dockerfile
@@ -1,6 +1,8 @@
 FROM debian:stretch-slim
 LABEL maintainer  Odoo S.A. <info@odoo.com>
 
+SHELL ["/bin/bash", "-xo", "pipefail", "-c"]
+
 # Generate locale C.UTF-8 for postgres and general locale data
 ENV LANG C.UTF-8
 
@@ -8,8 +10,7 @@ ENV LANG C.UTF-8
 RUN echo 'deb http://deb.debian.org/debian stretch-backports main' > /etc/apt/sources.list.d/backports.list
 
 # Install some deps, lessc and less-plugin-clean-css, and wkhtmltopdf
-RUN set -x; \
-        apt-get update \
+RUN apt-get update \
         && apt-get install -y --no-install-recommends \
             ca-certificates \
             curl \
@@ -37,8 +38,7 @@ RUN set -x; \
         && rm -rf /var/lib/apt/lists/* wkhtmltox.deb
 
 # install latest postgresql-client
-RUN set -x; \
-        echo 'deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main' > /etc/apt/sources.list.d/pgdg.list \
+RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main' > /etc/apt/sources.list.d/pgdg.list \
         && export GNUPGHOME="$(mktemp -d)" \
         && repokey='B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8' \
         && gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "${repokey}" \
@@ -53,8 +53,7 @@ RUN set -x; \
 ENV ODOO_VERSION 11.0
 ARG ODOO_RELEASE=20200121
 ARG ODOO_SHA=13f30434cb4fb28b11d78fd4e7c616d03362f779
-RUN set -x; \
-        curl -o odoo.deb -sSL http://nightly.odoo.com/${ODOO_VERSION}/nightly/deb/odoo_${ODOO_VERSION}.${ODOO_RELEASE}_all.deb \
+RUN curl -o odoo.deb -sSL http://nightly.odoo.com/${ODOO_VERSION}/nightly/deb/odoo_${ODOO_VERSION}.${ODOO_RELEASE}_all.deb \
         && echo "${ODOO_SHA} odoo.deb" | sha1sum -c - \
         && dpkg --force-depends -i odoo.deb \
         && apt-get update \

--- a/11.0/Dockerfile
+++ b/11.0/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:stretch-slim
-MAINTAINER Odoo S.A. <info@odoo.com>
+LABEL maintainer  Odoo S.A. <info@odoo.com>
 
 # Generate locale C.UTF-8 for postgres and general locale data
 ENV LANG C.UTF-8

--- a/11.0/Dockerfile
+++ b/11.0/Dockerfile
@@ -11,53 +11,53 @@ RUN echo 'deb http://deb.debian.org/debian stretch-backports main' > /etc/apt/so
 
 # Install some deps, lessc and less-plugin-clean-css, and wkhtmltopdf
 RUN apt-get update \
-        && apt-get install -y --no-install-recommends \
-            ca-certificates \
-            curl \
-            dirmngr \
-            fonts-noto-cjk \
-            gnupg \
-            libssl1.0-dev \
-            node-less \
-            python3-num2words \
-            python3-pip \
-            python3-phonenumbers \
-            python3-pyldap \
-            python3-qrcode \
-            python3-renderpm \
-            python3-setuptools \
-            python3-slugify \
-            python3-vobject \
-            python3-watchdog \
-            python3-xlrd \
-            python3-xlwt \
-            xz-utils \
-        && curl -o wkhtmltox.deb -sSL https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.stretch_amd64.deb \
-        && echo '7e35a63f9db14f93ec7feeb0fce76b30c08f2057 wkhtmltox.deb' | sha1sum -c - \
-        && apt-get install -y --no-install-recommends ./wkhtmltox.deb \
-        && rm -rf /var/lib/apt/lists/* wkhtmltox.deb
+ && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        dirmngr \
+        fonts-noto-cjk \
+        gnupg \
+        libssl1.0-dev \
+        node-less \
+        python3-num2words \
+        python3-pip \
+        python3-phonenumbers \
+        python3-pyldap \
+        python3-qrcode \
+        python3-renderpm \
+        python3-setuptools \
+        python3-slugify \
+        python3-vobject \
+        python3-watchdog \
+        python3-xlrd \
+        python3-xlwt \
+        xz-utils \
+ && curl -o wkhtmltox.deb -sSL https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.stretch_amd64.deb \
+ && echo '7e35a63f9db14f93ec7feeb0fce76b30c08f2057 wkhtmltox.deb' | sha1sum -c - \
+ && apt-get install -y --no-install-recommends ./wkhtmltox.deb \
+ && rm -rf /var/lib/apt/lists/* wkhtmltox.deb
 
 # install latest postgresql-client
 RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main' > /etc/apt/sources.list.d/pgdg.list \
-        && export GNUPGHOME="$(mktemp -d)" \
-        && repokey='B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8' \
-        && gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "${repokey}" \
-        && gpg --batch --armor --export "${repokey}" > /etc/apt/trusted.gpg.d/pgdg.gpg.asc \
-        && gpgconf --kill all \
-        && rm -rf "$GNUPGHOME" \
-        && apt-get update  \
-        && apt-get install -y postgresql-client \
-        && rm -rf /var/lib/apt/lists/*
+ && export GNUPGHOME="$(mktemp -d)" \
+ && repokey='B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8' \
+ && gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "${repokey}" \
+ && gpg --batch --armor --export "${repokey}" > /etc/apt/trusted.gpg.d/pgdg.gpg.asc \
+ && gpgconf --kill all \
+ && rm -rf "$GNUPGHOME" \
+ && apt-get update  \
+ && apt-get install -y postgresql-client \
+ && rm -rf /var/lib/apt/lists/*
 
 # Install Odoo
 ENV ODOO_VERSION 11.0
 ARG ODOO_RELEASE=20200121
 ARG ODOO_SHA=13f30434cb4fb28b11d78fd4e7c616d03362f779
 RUN curl -o odoo.deb -sSL http://nightly.odoo.com/${ODOO_VERSION}/nightly/deb/odoo_${ODOO_VERSION}.${ODOO_RELEASE}_all.deb \
-        && echo "${ODOO_SHA} odoo.deb" | sha1sum -c - \
-        && apt-get update \
-        && apt-get -y install --no-install-recommends ./odoo.deb\
-        && rm -rf /var/lib/apt/lists/* odoo.deb
+ && echo "${ODOO_SHA} odoo.deb" | sha1sum -c - \
+ && apt-get update \
+ && apt-get -y install --no-install-recommends ./odoo.deb\
+ && rm -rf /var/lib/apt/lists/* odoo.deb
 
 # Copy entrypoint script and Odoo configuration file
 COPY ./entrypoint.sh /
@@ -65,8 +65,8 @@ COPY ./odoo.conf /etc/odoo/
 
 # Mount /var/lib/odoo to allow restoring filestore and /mnt/extra-addons for users addons
 RUN chown odoo /etc/odoo/odoo.conf \
-    && mkdir -p /mnt/extra-addons \
-    && chown -R odoo /mnt/extra-addons
+ && mkdir -p /mnt/extra-addons \
+ && chown -R odoo /mnt/extra-addons
 VOLUME ["/var/lib/odoo", "/mnt/extra-addons"]
 
 # Expose Odoo services

--- a/12.0/Dockerfile
+++ b/12.0/Dockerfile
@@ -1,6 +1,8 @@
 FROM debian:stretch-slim
 LABEL maintainer  Odoo S.A. <info@odoo.com>
 
+SHELL ["/bin/bash", "-xo", "pipefail", "-c"]
+
 # Generate locale C.UTF-8 for postgres and general locale data
 ENV LANG C.UTF-8
 
@@ -8,8 +10,7 @@ ENV LANG C.UTF-8
 RUN echo 'deb http://deb.debian.org/debian stretch-backports main' > /etc/apt/sources.list.d/backports.list
 
 # Install some deps, lessc and less-plugin-clean-css, and wkhtmltopdf
-RUN set -x; \
-        apt-get update \
+RUN apt-get update \
         && apt-get install -y --no-install-recommends \
             ca-certificates \
             curl \
@@ -37,8 +38,7 @@ RUN set -x; \
         && rm -rf /var/lib/apt/lists/* wkhtmltox.deb
 
 # install latest postgresql-client
-RUN set -x; \
-        echo 'deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main' > /etc/apt/sources.list.d/pgdg.list \
+RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main' > /etc/apt/sources.list.d/pgdg.list \
         && export GNUPGHOME="$(mktemp -d)" \
         && repokey='B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8' \
         && gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "${repokey}" \
@@ -50,8 +50,7 @@ RUN set -x; \
         && rm -rf /var/lib/apt/lists/*
 
 # Install rtlcss (on Debian stretch)
-RUN set -x;\
-    echo "deb http://deb.nodesource.com/node_8.x stretch main" > /etc/apt/sources.list.d/nodesource.list \
+RUN echo "deb http://deb.nodesource.com/node_8.x stretch main" > /etc/apt/sources.list.d/nodesource.list \
     && export GNUPGHOME="$(mktemp -d)" \
     && repokey='9FD3B784BC1C6FC31A8A0A1C1655A0AB68576280' \
     && gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "${repokey}" \
@@ -67,8 +66,7 @@ RUN set -x;\
 ENV ODOO_VERSION 12.0
 ARG ODOO_RELEASE=20200121
 ARG ODOO_SHA=cb0bcb5d239983468c2e3b3f7cf17f58df820b1c
-RUN set -x; \
-        curl -o odoo.deb -sSL http://nightly.odoo.com/${ODOO_VERSION}/nightly/deb/odoo_${ODOO_VERSION}.${ODOO_RELEASE}_all.deb \
+RUN curl -o odoo.deb -sSL http://nightly.odoo.com/${ODOO_VERSION}/nightly/deb/odoo_${ODOO_VERSION}.${ODOO_RELEASE}_all.deb \
         && echo "${ODOO_SHA} odoo.deb" | sha1sum -c - \
         && dpkg --force-depends -i odoo.deb \
         && apt-get update \

--- a/12.0/Dockerfile
+++ b/12.0/Dockerfile
@@ -68,9 +68,8 @@ ARG ODOO_RELEASE=20200121
 ARG ODOO_SHA=cb0bcb5d239983468c2e3b3f7cf17f58df820b1c
 RUN curl -o odoo.deb -sSL http://nightly.odoo.com/${ODOO_VERSION}/nightly/deb/odoo_${ODOO_VERSION}.${ODOO_RELEASE}_all.deb \
         && echo "${ODOO_SHA} odoo.deb" | sha1sum -c - \
-        && dpkg --force-depends -i odoo.deb \
         && apt-get update \
-        && apt-get -y install -f --no-install-recommends \
+        && apt-get -y install --no-install-recommends ./odoo.deb \
         && rm -rf /var/lib/apt/lists/* odoo.deb
 
 # Copy entrypoint script and Odoo configuration file

--- a/12.0/Dockerfile
+++ b/12.0/Dockerfile
@@ -11,66 +11,66 @@ RUN echo 'deb http://deb.debian.org/debian stretch-backports main' > /etc/apt/so
 
 # Install some deps, lessc and less-plugin-clean-css, and wkhtmltopdf
 RUN apt-get update \
-        && apt-get install -y --no-install-recommends \
-            ca-certificates \
-            curl \
-            dirmngr \
-            fonts-noto-cjk \
-            gnupg \
-            libssl1.0-dev \
-            node-less \
-            python3-num2words \
-            python3-pip \
-            python3-phonenumbers \
-            python3-pyldap \
-            python3-qrcode \
-            python3-renderpm \
-            python3-setuptools \
-            python3-slugify \
-            python3-vobject \
-            python3-watchdog \
-            python3-xlrd \
-            python3-xlwt \
-            xz-utils \
-        && curl -o wkhtmltox.deb -sSL https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.stretch_amd64.deb \
-        && echo '7e35a63f9db14f93ec7feeb0fce76b30c08f2057 wkhtmltox.deb' | sha1sum -c - \
-        && apt-get install -y --no-install-recommends ./wkhtmltox.deb \
-        && rm -rf /var/lib/apt/lists/* wkhtmltox.deb
+ && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        dirmngr \
+        fonts-noto-cjk \
+        gnupg \
+        libssl1.0-dev \
+        node-less \
+        python3-num2words \
+        python3-pip \
+        python3-phonenumbers \
+        python3-pyldap \
+        python3-qrcode \
+        python3-renderpm \
+        python3-setuptools \
+        python3-slugify \
+        python3-vobject \
+        python3-watchdog \
+        python3-xlrd \
+        python3-xlwt \
+        xz-utils \
+ && curl -o wkhtmltox.deb -sSL https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.stretch_amd64.deb \
+ && echo '7e35a63f9db14f93ec7feeb0fce76b30c08f2057 wkhtmltox.deb' | sha1sum -c - \
+ && apt-get install -y --no-install-recommends ./wkhtmltox.deb \
+ && rm -rf /var/lib/apt/lists/* wkhtmltox.deb
 
 # install latest postgresql-client
 RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main' > /etc/apt/sources.list.d/pgdg.list \
-        && export GNUPGHOME="$(mktemp -d)" \
-        && repokey='B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8' \
-        && gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "${repokey}" \
-        && gpg --batch --armor --export "${repokey}" > /etc/apt/trusted.gpg.d/pgdg.gpg.asc \
-        && gpgconf --kill all \
-        && rm -rf "$GNUPGHOME" \
-        && apt-get update  \
-        && apt-get install -y postgresql-client \
-        && rm -rf /var/lib/apt/lists/*
+ && export GNUPGHOME="$(mktemp -d)" \
+ && repokey='B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8' \
+ && gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "${repokey}" \
+ && gpg --batch --armor --export "${repokey}" > /etc/apt/trusted.gpg.d/pgdg.gpg.asc \
+ && gpgconf --kill all \
+ && rm -rf "$GNUPGHOME" \
+ && apt-get update  \
+ && apt-get install -y postgresql-client \
+ && rm -rf /var/lib/apt/lists/*
 
 # Install rtlcss (on Debian stretch)
 RUN echo "deb http://deb.nodesource.com/node_8.x stretch main" > /etc/apt/sources.list.d/nodesource.list \
-    && export GNUPGHOME="$(mktemp -d)" \
-    && repokey='9FD3B784BC1C6FC31A8A0A1C1655A0AB68576280' \
-    && gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "${repokey}" \
-    && gpg --batch --armor --export "${repokey}" > /etc/apt/trusted.gpg.d/nodejs.gpg.asc \
-    && gpgconf --kill all \
-    && rm -rf "$GNUPGHOME" \
-    && apt-get update \
-    && apt-get install -y nodejs \
-    && npm install -g rtlcss \
-    && rm -rf /var/lib/apt/lists/*
+ && export GNUPGHOME="$(mktemp -d)" \
+ && repokey='9FD3B784BC1C6FC31A8A0A1C1655A0AB68576280' \
+ && gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "${repokey}" \
+ && gpg --batch --armor --export "${repokey}" > /etc/apt/trusted.gpg.d/nodejs.gpg.asc \
+ && gpgconf --kill all \
+ && rm -rf "$GNUPGHOME" \
+ && apt-get update \
+ && apt-get install -y nodejs \
+ && npm install -g rtlcss \
+ && rm -rf /var/lib/apt/lists/*
 
 # Install Odoo
 ENV ODOO_VERSION 12.0
 ARG ODOO_RELEASE=20200121
 ARG ODOO_SHA=cb0bcb5d239983468c2e3b3f7cf17f58df820b1c
 RUN curl -o odoo.deb -sSL http://nightly.odoo.com/${ODOO_VERSION}/nightly/deb/odoo_${ODOO_VERSION}.${ODOO_RELEASE}_all.deb \
-        && echo "${ODOO_SHA} odoo.deb" | sha1sum -c - \
-        && apt-get update \
-        && apt-get -y install --no-install-recommends ./odoo.deb \
-        && rm -rf /var/lib/apt/lists/* odoo.deb
+ && echo "${ODOO_SHA} odoo.deb" | sha1sum -c - \
+ && apt-get update \
+ && apt-get -y install --no-install-recommends ./odoo.deb \
+ && rm -rf /var/lib/apt/lists/* odoo.deb
 
 # Copy entrypoint script and Odoo configuration file
 COPY ./entrypoint.sh /
@@ -78,8 +78,8 @@ COPY ./odoo.conf /etc/odoo/
 
 # Mount /var/lib/odoo to allow restoring filestore and /mnt/extra-addons for users addons
 RUN chown odoo /etc/odoo/odoo.conf \
-    && mkdir -p /mnt/extra-addons \
-    && chown -R odoo /mnt/extra-addons
+ && mkdir -p /mnt/extra-addons \
+ && chown -R odoo /mnt/extra-addons
 VOLUME ["/var/lib/odoo", "/mnt/extra-addons"]
 
 # Expose Odoo services

--- a/12.0/Dockerfile
+++ b/12.0/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:stretch-slim
-MAINTAINER Odoo S.A. <info@odoo.com>
+LABEL maintainer  Odoo S.A. <info@odoo.com>
 
 # Generate locale C.UTF-8 for postgres and general locale data
 ENV LANG C.UTF-8

--- a/13.0/Dockerfile
+++ b/13.0/Dockerfile
@@ -1,12 +1,13 @@
 FROM debian:buster-slim
 LABEL maintainer  Odoo S.A. <info@odoo.com>
 
+SHELL ["/bin/bash", "-xo", "pipefail", "-c"]
+
 # Generate locale C.UTF-8 for postgres and general locale data
 ENV LANG C.UTF-8
 
 # Install some deps, lessc and less-plugin-clean-css, and wkhtmltopdf
-RUN set -x; \
-        apt-get update \
+RUN apt-get update \
         && apt-get install -y --no-install-recommends \
             ca-certificates \
             curl \
@@ -35,8 +36,7 @@ RUN set -x; \
         && rm -rf /var/lib/apt/lists/* wkhtmltox.deb
 
 # install latest postgresql-client
-RUN set -x; \
-        echo 'deb http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main' > /etc/apt/sources.list.d/pgdg.list \
+RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main' > /etc/apt/sources.list.d/pgdg.list \
         && export GNUPGHOME="$(mktemp -d)" \
         && repokey='B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8' \
         && gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "${repokey}" \
@@ -48,15 +48,13 @@ RUN set -x; \
         && rm -rf /var/lib/apt/lists/*
 
 # Install rtlcss (on Debian buster)
-RUN set -x; \
-    npm install -g rtlcss
+RUN npm install -g rtlcss
 
 # Install Odoo
 ENV ODOO_VERSION 13.0
 ARG ODOO_RELEASE=20200121
 ARG ODOO_SHA=770d71cfafb9a8f8419b88f8033b964d5742ad57
-RUN set -x; \
-        curl -o odoo.deb -sSL http://nightly.odoo.com/${ODOO_VERSION}/nightly/deb/odoo_${ODOO_VERSION}.${ODOO_RELEASE}_all.deb \
+RUN curl -o odoo.deb -sSL http://nightly.odoo.com/${ODOO_VERSION}/nightly/deb/odoo_${ODOO_VERSION}.${ODOO_RELEASE}_all.deb \
         && echo "${ODOO_SHA} odoo.deb" | sha1sum -c - \
         && dpkg --force-depends -i odoo.deb \
         && apt-get update \

--- a/13.0/Dockerfile
+++ b/13.0/Dockerfile
@@ -56,9 +56,8 @@ ARG ODOO_RELEASE=20200121
 ARG ODOO_SHA=770d71cfafb9a8f8419b88f8033b964d5742ad57
 RUN curl -o odoo.deb -sSL http://nightly.odoo.com/${ODOO_VERSION}/nightly/deb/odoo_${ODOO_VERSION}.${ODOO_RELEASE}_all.deb \
         && echo "${ODOO_SHA} odoo.deb" | sha1sum -c - \
-        && dpkg --force-depends -i odoo.deb \
         && apt-get update \
-        && apt-get -y install -f --no-install-recommends \
+        && apt-get -y install --no-install-recommends odoo.deb \
         && rm -rf /var/lib/apt/lists/* odoo.deb
 
 # Copy entrypoint script and Odoo configuration file

--- a/13.0/Dockerfile
+++ b/13.0/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:buster-slim
-MAINTAINER Odoo S.A. <info@odoo.com>
+LABEL maintainer  Odoo S.A. <info@odoo.com>
 
 # Generate locale C.UTF-8 for postgres and general locale data
 ENV LANG C.UTF-8

--- a/13.0/Dockerfile
+++ b/13.0/Dockerfile
@@ -8,44 +8,44 @@ ENV LANG C.UTF-8
 
 # Install some deps, lessc and less-plugin-clean-css, and wkhtmltopdf
 RUN apt-get update \
-        && apt-get install -y --no-install-recommends \
-            ca-certificates \
-            curl \
-            dirmngr \
-            fonts-noto-cjk \
-            gnupg \
-            libssl-dev \
-            node-less \
-            npm \
-            python3-num2words \
-            python3-pip \
-            python3-phonenumbers \
-            python3-pyldap \
-            python3-qrcode \
-            python3-renderpm \
-            python3-setuptools \
-            python3-slugify \
-            python3-vobject \
-            python3-watchdog \
-            python3-xlrd \
-            python3-xlwt \
-            xz-utils \
-        && curl -o wkhtmltox.deb -sSL https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.stretch_amd64.deb \
-        && echo '7e35a63f9db14f93ec7feeb0fce76b30c08f2057 wkhtmltox.deb' | sha1sum -c - \
-        && apt-get install -y --no-install-recommends ./wkhtmltox.deb \
-        && rm -rf /var/lib/apt/lists/* wkhtmltox.deb
+ && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        dirmngr \
+        fonts-noto-cjk \
+        gnupg \
+        libssl-dev \
+        node-less \
+        npm \
+        python3-num2words \
+        python3-pip \
+        python3-phonenumbers \
+        python3-pyldap \
+        python3-qrcode \
+        python3-renderpm \
+        python3-setuptools \
+        python3-slugify \
+        python3-vobject \
+        python3-watchdog \
+        python3-xlrd \
+        python3-xlwt \
+        xz-utils \
+ && curl -o wkhtmltox.deb -sSL https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox_0.12.5-1.stretch_amd64.deb \
+ && echo '7e35a63f9db14f93ec7feeb0fce76b30c08f2057 wkhtmltox.deb' | sha1sum -c - \
+ && apt-get install -y --no-install-recommends ./wkhtmltox.deb \
+ && rm -rf /var/lib/apt/lists/* wkhtmltox.deb
 
 # install latest postgresql-client
 RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main' > /etc/apt/sources.list.d/pgdg.list \
-        && export GNUPGHOME="$(mktemp -d)" \
-        && repokey='B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8' \
-        && gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "${repokey}" \
-        && gpg --batch --armor --export "${repokey}" > /etc/apt/trusted.gpg.d/pgdg.gpg.asc \
-        && gpgconf --kill all \
-        && rm -rf "$GNUPGHOME" \
-        && apt-get update  \
-        && apt-get install -y postgresql-client \
-        && rm -rf /var/lib/apt/lists/*
+ && export GNUPGHOME="$(mktemp -d)" \
+ && repokey='B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8' \
+ && gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "${repokey}" \
+ && gpg --batch --armor --export "${repokey}" > /etc/apt/trusted.gpg.d/pgdg.gpg.asc \
+ && gpgconf --kill all \
+ && rm -rf "$GNUPGHOME" \
+ && apt-get update  \
+ && apt-get install -y postgresql-client \
+ && rm -rf /var/lib/apt/lists/*
 
 # Install rtlcss (on Debian buster)
 RUN npm install -g rtlcss
@@ -55,10 +55,10 @@ ENV ODOO_VERSION 13.0
 ARG ODOO_RELEASE=20200121
 ARG ODOO_SHA=770d71cfafb9a8f8419b88f8033b964d5742ad57
 RUN curl -o odoo.deb -sSL http://nightly.odoo.com/${ODOO_VERSION}/nightly/deb/odoo_${ODOO_VERSION}.${ODOO_RELEASE}_all.deb \
-        && echo "${ODOO_SHA} odoo.deb" | sha1sum -c - \
-        && apt-get update \
-        && apt-get -y install --no-install-recommends odoo.deb \
-        && rm -rf /var/lib/apt/lists/* odoo.deb
+ && echo "${ODOO_SHA} odoo.deb" | sha1sum -c - \
+ && apt-get update \
+ && apt-get -y install --no-install-recommends ./odoo.deb \
+ && rm -rf /var/lib/apt/lists/* odoo.deb
 
 # Copy entrypoint script and Odoo configuration file
 COPY ./entrypoint.sh /
@@ -66,8 +66,8 @@ COPY ./odoo.conf /etc/odoo/
 
 # Set permissions and Mount /var/lib/odoo to allow restoring filestore and /mnt/extra-addons for users addons
 RUN chown odoo /etc/odoo/odoo.conf \
-    && mkdir -p /mnt/extra-addons \
-    && chown -R odoo /mnt/extra-addons
+ && mkdir -p /mnt/extra-addons \
+ && chown -R odoo /mnt/extra-addons
 VOLUME ["/var/lib/odoo", "/mnt/extra-addons"]
 
 # Expose Odoo services


### PR DESCRIPTION
Dear Team,

I've fixed/improved the three Dockerfiles:

- set shell explicitely, because you've used set -x on every RUN layer. It's code repetition plus Debian/Ubuntu defaults to Dash instead of Bash. Dash is a simple shell, do not want any advanced feature or switches from it. IMHO these things can be highly unpredictable with Dash.
- removed the dpkg commands, because you were breaking the system packages then fixed it with apt-get. Pointless and wasting of time. apt-get can install locally download packages too with all their dependencies.
- I've changed the old MAINTAINER to the newer, LABEL directive.
- and re-indented all three Dockerfiles. I know, it's not a good practice (especially for the first pull request). Sorry, but they looked ugly with 2-3 different indentation types in the very same files. (Unfortunately it tells a lot, especially about a python project.)

Best regards,
Andras