### PR TITLE
[IMP] add option to customize wait-for-psql.py timeout

### DIFF
--- a/12.0/entrypoint.sh
+++ b/12.0/entrypoint.sh
@@ -8,17 +8,23 @@ set -e
 : ${PORT:=${DB_PORT_5432_TCP_PORT:=5432}}
 : ${USER:=${DB_ENV_POSTGRES_USER:=${POSTGRES_USER:='odoo'}}}
 : ${PASSWORD:=${DB_ENV_POSTGRES_PASSWORD:=${POSTGRES_PASSWORD:='odoo'}}}
+: ${PSQL_TIMEOUT:=${DB_INIT_TIMEOUT:=30}}
 
 DB_ARGS=()
 function check_config() {
     param="$1"
     value="$2"
-    if grep -q -E "^\s*\b${param}\b\s*=" "$ODOO_RC" ; then       
-        value=$(grep -E "^\s*\b${param}\b\s*=" "$ODOO_RC" |cut -d " " -f3|sed 's/["\n\r]//g')
-    fi;
+    if grep -q -E "^\s*\b${param}\b\s*=" "$ODOO_RC"; then
+        value=$(
+            grep -E "^\s*\b${param}\b\s*=" "$ODOO_RC" \
+                | cut -d " " -f3 \
+                | sed 's/["\n\r]//g'
+        )
+    fi
     DB_ARGS+=("--${param}")
     DB_ARGS+=("${value}")
 }
+
 check_config "db_host" "$HOST"
 check_config "db_port" "$PORT"
 check_config "db_user" "$USER"
@@ -30,12 +36,12 @@ case "$1" in
         if [[ "$1" == "scaffold" ]] ; then
             exec odoo "$@"
         else
-            wait-for-psql.py ${DB_ARGS[@]} --timeout=30
+            wait-for-psql.py ${DB_ARGS[@]} --timeout=$PSQL_TIMEOUT
             exec odoo "$@" "${DB_ARGS[@]}"
         fi
         ;;
     -*)
-        wait-for-psql.py ${DB_ARGS[@]} --timeout=30
+        wait-for-psql.py ${DB_ARGS[@]} --timeout=$PSQL_TIMEOUT
         exec odoo "$@" "${DB_ARGS[@]}"
         ;;
     *)

--- a/13.0/entrypoint.sh
+++ b/13.0/entrypoint.sh
@@ -8,17 +8,23 @@ set -e
 : ${PORT:=${DB_PORT_5432_TCP_PORT:=5432}}
 : ${USER:=${DB_ENV_POSTGRES_USER:=${POSTGRES_USER:='odoo'}}}
 : ${PASSWORD:=${DB_ENV_POSTGRES_PASSWORD:=${POSTGRES_PASSWORD:='odoo'}}}
+: ${PSQL_TIMEOUT:=${DB_INIT_TIMEOUT:=30}}
 
 DB_ARGS=()
 function check_config() {
     param="$1"
     value="$2"
-    if grep -q -E "^\s*\b${param}\b\s*=" "$ODOO_RC" ; then       
-        value=$(grep -E "^\s*\b${param}\b\s*=" "$ODOO_RC" |cut -d " " -f3|sed 's/["\n\r]//g')
-    fi;
+    if grep -q -E "^\s*\b${param}\b\s*=" "$ODOO_RC"; then
+        value=$(
+            grep -E "^\s*\b${param}\b\s*=" "$ODOO_RC" \
+                | cut -d " " -f3 \
+                | sed 's/["\n\r]//g'
+        )
+    fi
     DB_ARGS+=("--${param}")
     DB_ARGS+=("${value}")
 }
+
 check_config "db_host" "$HOST"
 check_config "db_port" "$PORT"
 check_config "db_user" "$USER"
@@ -30,12 +36,12 @@ case "$1" in
         if [[ "$1" == "scaffold" ]] ; then
             exec odoo "$@"
         else
-            wait-for-psql.py ${DB_ARGS[@]} --timeout=30
+            wait-for-psql.py ${DB_ARGS[@]} --timeout=$PSQL_TIMEOUT
             exec odoo "$@" "${DB_ARGS[@]}"
         fi
         ;;
     -*)
-        wait-for-psql.py ${DB_ARGS[@]} --timeout=30
+        wait-for-psql.py ${DB_ARGS[@]} --timeout=$PSQL_TIMEOUT
         exec odoo "$@" "${DB_ARGS[@]}"
         ;;
     *)

--- a/14.0/entrypoint.sh
+++ b/14.0/entrypoint.sh
@@ -8,17 +8,23 @@ set -e
 : ${PORT:=${DB_PORT_5432_TCP_PORT:=5432}}
 : ${USER:=${DB_ENV_POSTGRES_USER:=${POSTGRES_USER:='odoo'}}}
 : ${PASSWORD:=${DB_ENV_POSTGRES_PASSWORD:=${POSTGRES_PASSWORD:='odoo'}}}
+: ${PSQL_TIMEOUT:=${DB_INIT_TIMEOUT:=30}}
 
 DB_ARGS=()
 function check_config() {
     param="$1"
     value="$2"
-    if grep -q -E "^\s*\b${param}\b\s*=" "$ODOO_RC" ; then       
-        value=$(grep -E "^\s*\b${param}\b\s*=" "$ODOO_RC" |cut -d " " -f3|sed 's/["\n\r]//g')
-    fi;
+    if grep -q -E "^\s*\b${param}\b\s*=" "$ODOO_RC"; then
+        value=$(
+            grep -E "^\s*\b${param}\b\s*=" "$ODOO_RC" \
+                | cut -d " " -f3 \
+                | sed 's/["\n\r]//g'
+        )
+    fi
     DB_ARGS+=("--${param}")
     DB_ARGS+=("${value}")
 }
+
 check_config "db_host" "$HOST"
 check_config "db_port" "$PORT"
 check_config "db_user" "$USER"
@@ -30,12 +36,12 @@ case "$1" in
         if [[ "$1" == "scaffold" ]] ; then
             exec odoo "$@"
         else
-            wait-for-psql.py ${DB_ARGS[@]} --timeout=30
+            wait-for-psql.py ${DB_ARGS[@]} --timeout=$PSQL_TIMEOUT
             exec odoo "$@" "${DB_ARGS[@]}"
         fi
         ;;
     -*)
-        wait-for-psql.py ${DB_ARGS[@]} --timeout=30
+        wait-for-psql.py ${DB_ARGS[@]} --timeout=$PSQL_TIMEOUT
         exec odoo "$@" "${DB_ARGS[@]}"
         ;;
     *)


### PR DESCRIPTION
Allow users to pass a custom timeout value for the `wait-for-psql.py` script to the container via the `PSQL_TIMEOUT` environment variable.
The timeout of 30 seconds still remains the default.

### Background

In our Kubernetes cluster the startup of the postgresql container takes sometimes a little longer than 30 seconds. This change offers users to adjust the timeout to a higher value to prevent the odoo container from getting stuck.