### PR TITLE
Fix: [14.0] Logs not accesible from docker log

### DIFF
--- a/14.0/Dockerfile
+++ b/14.0/Dockerfile
@@ -73,6 +73,9 @@ RUN chown odoo /etc/odoo/odoo.conf \
     && chown -R odoo /mnt/extra-addons
 VOLUME ["/var/lib/odoo", "/mnt/extra-addons"]
 
+# Forward logs to STDOUT (Docker Log collector)
+RUN ln -sf /dev/stdout /var/log/odoo/odoo-server.log
+
 # Expose Odoo services
 EXPOSE 8069 8071 8072
 


### PR DESCRIPTION
Added symbolic link between /var/log/odoo/odoo-server.log and /dev/stdout  so logs can be handled with docker log collector.