### PR TITLE
parameterize db_name

### DIFF
--- a/14.0/wait-for-psql.py
+++ b/14.0/wait-for-psql.py
@@ -7,6 +7,7 @@ import time
 
 if __name__ == '__main__':
     arg_parser = argparse.ArgumentParser()
+    arg_parser.add_argument('--db_name', required=True, default='postgres')
     arg_parser.add_argument('--db_host', required=True)
     arg_parser.add_argument('--db_port', required=True)
     arg_parser.add_argument('--db_user', required=True)
@@ -18,7 +19,7 @@ if __name__ == '__main__':
     start_time = time.time()
     while (time.time() - start_time) < args.timeout:
         try:
-            conn = psycopg2.connect(user=args.db_user, host=args.db_host, port=args.db_port, password=args.db_password, dbname='postgres')
+            conn = psycopg2.connect(user=args.db_user, host=args.db_host, port=args.db_port, password=args.db_password, dbname=args.db_name)
             error = ''
             break
         except psycopg2.OperationalError as e:

--- a/15.0/wait-for-psql.py
+++ b/15.0/wait-for-psql.py
@@ -7,6 +7,7 @@ import time
 
 if __name__ == '__main__':
     arg_parser = argparse.ArgumentParser()
+    arg_parser.add_argument('--db_name', required=True, default='postgres')
     arg_parser.add_argument('--db_host', required=True)
     arg_parser.add_argument('--db_port', required=True)
     arg_parser.add_argument('--db_user', required=True)
@@ -18,7 +19,7 @@ if __name__ == '__main__':
     start_time = time.time()
     while (time.time() - start_time) < args.timeout:
         try:
-            conn = psycopg2.connect(user=args.db_user, host=args.db_host, port=args.db_port, password=args.db_password, dbname='postgres')
+            conn = psycopg2.connect(user=args.db_user, host=args.db_host, port=args.db_port, password=args.db_password, dbname=args.db_name)
             error = ''
             break
         except psycopg2.OperationalError as e:

--- a/16.0/wait-for-psql.py
+++ b/16.0/wait-for-psql.py
@@ -7,6 +7,7 @@ import time
 
 if __name__ == '__main__':
     arg_parser = argparse.ArgumentParser()
+    arg_parser.add_argument('--db_name', required=True, default='postgres')
     arg_parser.add_argument('--db_host', required=True)
     arg_parser.add_argument('--db_port', required=True)
     arg_parser.add_argument('--db_user', required=True)
@@ -18,7 +19,7 @@ if __name__ == '__main__':
     start_time = time.time()
     while (time.time() - start_time) < args.timeout:
         try:
-            conn = psycopg2.connect(user=args.db_user, host=args.db_host, port=args.db_port, password=args.db_password, dbname='postgres')
+            conn = psycopg2.connect(user=args.db_user, host=args.db_host, port=args.db_port, password=args.db_password, dbname=args.db_name)
             error = ''
             break
         except psycopg2.OperationalError as e:


### PR DESCRIPTION
In case the database name is not `postgres`, the current image completely fails to run with the error:

```
Database connection failure: connection to server at "..." (ip-address), port ... failed: FATAL:  database "postgres" does not exist
```

This PR parameterizes the db name so the admin can spin up the image without having to hack-around this limitation.