### PR TITLE
[IMP] Use latest nightly build by default

### DIFF
--- a/14.0/Dockerfile
+++ b/14.0/Dockerfile
@@ -55,10 +55,12 @@ RUN npm install -g rtlcss
 
 # Install Odoo
 ENV ODOO_VERSION 14.0
-ARG ODOO_RELEASE=20230109
-ARG ODOO_SHA=ef9eef9a5e5bbeb455ac7d1c05cc675e74876609
-RUN curl -o odoo.deb -sSL http://nightly.odoo.com/${ODOO_VERSION}/nightly/deb/odoo_${ODOO_VERSION}.${ODOO_RELEASE}_all.deb \
-    && echo "${ODOO_SHA} odoo.deb" | sha1sum -c - \
+ARG ODOO_RELEASE=latest
+ARG ODOO_SHA
+RUN latest_sha1=$(curl -sSL http://nightly.odoo.com/${ODOO_VERSION}/nightly/deb/Packages | grep -e "^SHA1:" | sed "s/SHA1: //") \
+    && sha_value=${ODOO_SHA-${latest_sha1}} \
+    && curl -o odoo.deb -sSL http://nightly.odoo.com/${ODOO_VERSION}/nightly/deb/odoo_${ODOO_VERSION}.${ODOO_RELEASE}_all.deb \
+    && echo "${sha_value} odoo.deb" | sha1sum -c - \
     && apt-get update \
     && apt-get -y install --no-install-recommends ./odoo.deb \
     && rm -rf /var/lib/apt/lists/* odoo.deb

--- a/15.0/Dockerfile
+++ b/15.0/Dockerfile
@@ -55,10 +55,12 @@ RUN npm install -g rtlcss
 
 # Install Odoo
 ENV ODOO_VERSION 15.0
-ARG ODOO_RELEASE=20230109
-ARG ODOO_SHA=618e45490616f63dfb68077523c2971cbb6cdda7
-RUN curl -o odoo.deb -sSL http://nightly.odoo.com/${ODOO_VERSION}/nightly/deb/odoo_${ODOO_VERSION}.${ODOO_RELEASE}_all.deb \
-    && echo "${ODOO_SHA} odoo.deb" | sha1sum -c - \
+ARG ODOO_RELEASE=latest
+ARG ODOO_SHA
+RUN latest_sha1=$(curl -sSL http://nightly.odoo.com/${ODOO_VERSION}/nightly/deb/Packages | grep -e "^SHA1:" | sed "s/SHA1: //") \
+    && sha_value=${ODOO_SHA-${latest_sha1}} \
+    && curl -o odoo.deb -sSL http://nightly.odoo.com/${ODOO_VERSION}/nightly/deb/odoo_${ODOO_VERSION}.${ODOO_RELEASE}_all.deb \
+    && echo "${sha_value} odoo.deb" | sha1sum -c - \
     && apt-get update \
     && apt-get -y install --no-install-recommends ./odoo.deb \
     && rm -rf /var/lib/apt/lists/* odoo.deb

--- a/16.0/Dockerfile
+++ b/16.0/Dockerfile
@@ -55,10 +55,12 @@ RUN npm install -g rtlcss
 
 # Install Odoo
 ENV ODOO_VERSION 16.0
-ARG ODOO_RELEASE=20230109
-ARG ODOO_SHA=884bf72c7318835b9ac56be2594032cbba7b8c7b
-RUN curl -o odoo.deb -sSL http://nightly.odoo.com/${ODOO_VERSION}/nightly/deb/odoo_${ODOO_VERSION}.${ODOO_RELEASE}_all.deb \
-    && echo "${ODOO_SHA} odoo.deb" | sha1sum -c - \
+ARG ODOO_RELEASE=latest
+ARG ODOO_SHA
+RUN latest_sha1=$(curl -sSL http://nightly.odoo.com/${ODOO_VERSION}/nightly/deb/Packages | grep -e "^SHA1:" | sed "s/SHA1: //") \
+    && sha_value=${ODOO_SHA-${latest_sha1}} \
+    && curl -o odoo.deb -sSL http://nightly.odoo.com/${ODOO_VERSION}/nightly/deb/odoo_${ODOO_VERSION}.${ODOO_RELEASE}_all.deb \
+    && echo "${sha_value} odoo.deb" | sha1sum -c - \
     && apt-get update \
     && apt-get -y install --no-install-recommends ./odoo.deb \
     && rm -rf /var/lib/apt/lists/* odoo.deb


### PR DESCRIPTION
Updated Dockerfile for versions 14.0, 15.0 and 16.0 to always use the "latest" nightly build available and automatically get the sha1 checksum for it.
Manually specifying the Odoo version and and sha1 checksum via build arguments is still possible.