### PR TITLE
Add support for setting database name in Docker env variables

### DIFF
--- a/16.0/entrypoint.sh
+++ b/16.0/entrypoint.sh
@@ -12,6 +12,7 @@ fi
 : ${PORT:=${DB_PORT_5432_TCP_PORT:=5432}}
 : ${USER:=${DB_ENV_POSTGRES_USER:=${POSTGRES_USER:='odoo'}}}
 : ${PASSWORD:=${DB_ENV_POSTGRES_PASSWORD:=${POSTGRES_PASSWORD:='odoo'}}}
+: ${DB_NAME:=${DB_ENV_POSTGRES_DB_NAME:=${POSTGRES_DB_NAME:='odoo'}}}
 
 DB_ARGS=()
 function check_config() {
@@ -27,6 +28,7 @@ check_config "db_host" "$HOST"
 check_config "db_port" "$PORT"
 check_config "db_user" "$USER"
 check_config "db_password" "$PASSWORD"
+check_config "db_name" "$DB_NAME"
 
 case "$1" in
     -- | odoo)

--- a/16.0/wait-for-psql.py
+++ b/16.0/wait-for-psql.py
@@ -11,6 +11,7 @@ if __name__ == '__main__':
     arg_parser.add_argument('--db_port', required=True)
     arg_parser.add_argument('--db_user', required=True)
     arg_parser.add_argument('--db_password', required=True)
+    arg_parser.add_argument('--db_name', required=True)
     arg_parser.add_argument('--timeout', type=int, default=5)
 
     args = arg_parser.parse_args()
@@ -18,7 +19,7 @@ if __name__ == '__main__':
     start_time = time.time()
     while (time.time() - start_time) < args.timeout:
         try:
-            conn = psycopg2.connect(user=args.db_user, host=args.db_host, port=args.db_port, password=args.db_password, dbname='postgres')
+            conn = psycopg2.connect(user=args.db_user, host=args.db_host, port=args.db_port, password=args.db_password, dbname=args.db_name)
             error = ''
             break
         except psycopg2.OperationalError as e:


### PR DESCRIPTION
Forcing the use of setting the database name to be 'postgres' can be restrictive when wanting to integrate the application with a pre-existing postgres db. It also enables unifying the username and db name which can be better when managing multiple different applications in a single PostgreSQL instance.