### PR TITLE
Update Dockerfile

### DIFF
--- a/14.0/Dockerfile
+++ b/14.0/Dockerfile
@@ -37,14 +37,8 @@ RUN apt-get update && \
     && rm -rf /var/lib/apt/lists/* wkhtmltox.deb
 
 # install latest postgresql-client
-RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main' > /etc/apt/sources.list.d/pgdg.list \
-    && GNUPGHOME="$(mktemp -d)" \
-    && export GNUPGHOME \
-    && repokey='B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8' \
-    && gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "${repokey}" \
-    && gpg --batch --armor --export "${repokey}" > /etc/apt/trusted.gpg.d/pgdg.gpg.asc \
-    && gpgconf --kill all \
-    && rm -rf "$GNUPGHOME" \
+RUN echo 'deb [signed-by=/etc/apt/trusted.gpg.d/pgdg.gpg.asc] http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main' > /etc/apt/sources.list.d/pgdg.list \
+    && curl -o /etc/apt/trusted.gpg.d/pgdg.gpg.asc --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc
     && apt-get update  \
     && apt-get install --no-install-recommends -y postgresql-client \
     && rm -f /etc/apt/sources.list.d/pgdg.list \


### PR DESCRIPTION
Fixed version 14 code to be usable with proxy (is cleaner too).

This way one can set HTTP(S) proxy in ENV vars higher up and file and it will work. Most proxies won't allow the port GPG uses by default and it's not easy to get GPG working with proxy consistently in my tests.

This way it's not required and more conform instructions from PostgreSQL here: https://wiki.postgresql.org/wiki/Apt