### PR TITLE
[IMP] Odoo 15.0-17.0: Make psycopg2.connect dbname configurable.

### DIFF
--- a/15.0/entrypoint.sh
+++ b/15.0/entrypoint.sh
@@ -10,6 +10,7 @@ fi
 # and pass them as arguments to the odoo process if not present in the config file
 : ${HOST:=${DB_PORT_5432_TCP_ADDR:='db'}}
 : ${PORT:=${DB_PORT_5432_TCP_PORT:=5432}}
+: ${NAME:=${DB_ENV_POSTGRES_DB:=${POSTGRES_DB:='postgres'}}}
 : ${USER:=${DB_ENV_POSTGRES_USER:=${POSTGRES_USER:='odoo'}}}
 : ${PASSWORD:=${DB_ENV_POSTGRES_PASSWORD:=${POSTGRES_PASSWORD:='odoo'}}}
 
@@ -23,6 +24,7 @@ function check_config() {
     DB_ARGS+=("--${param}")
     DB_ARGS+=("${value}")
 }
+check_config "database" "$NAME"
 check_config "db_host" "$HOST"
 check_config "db_port" "$PORT"
 check_config "db_user" "$USER"

--- a/15.0/wait-for-psql.py
+++ b/15.0/wait-for-psql.py
@@ -7,6 +7,7 @@ import time
 
 if __name__ == '__main__':
     arg_parser = argparse.ArgumentParser()
+    arg_parser.add_argument('--database', required=True)
     arg_parser.add_argument('--db_host', required=True)
     arg_parser.add_argument('--db_port', required=True)
     arg_parser.add_argument('--db_user', required=True)
@@ -18,7 +19,7 @@ if __name__ == '__main__':
     start_time = time.time()
     while (time.time() - start_time) < args.timeout:
         try:
-            conn = psycopg2.connect(user=args.db_user, host=args.db_host, port=args.db_port, password=args.db_password, dbname='postgres')
+            conn = psycopg2.connect(user=args.db_user, host=args.db_host, port=args.db_port, password=args.db_password, dbname=args.database)
             error = ''
             break
         except psycopg2.OperationalError as e:

--- a/16.0/entrypoint.sh
+++ b/16.0/entrypoint.sh
@@ -10,6 +10,7 @@ fi
 # and pass them as arguments to the odoo process if not present in the config file
 : ${HOST:=${DB_PORT_5432_TCP_ADDR:='db'}}
 : ${PORT:=${DB_PORT_5432_TCP_PORT:=5432}}
+: ${NAME:=${DB_ENV_POSTGRES_DB:=${POSTGRES_DB:='postgres'}}}
 : ${USER:=${DB_ENV_POSTGRES_USER:=${POSTGRES_USER:='odoo'}}}
 : ${PASSWORD:=${DB_ENV_POSTGRES_PASSWORD:=${POSTGRES_PASSWORD:='odoo'}}}
 
@@ -23,6 +24,7 @@ function check_config() {
     DB_ARGS+=("--${param}")
     DB_ARGS+=("${value}")
 }
+check_config "database" "$NAME"
 check_config "db_host" "$HOST"
 check_config "db_port" "$PORT"
 check_config "db_user" "$USER"

--- a/16.0/wait-for-psql.py
+++ b/16.0/wait-for-psql.py
@@ -7,6 +7,7 @@ import time
 
 if __name__ == '__main__':
     arg_parser = argparse.ArgumentParser()
+    arg_parser.add_argument('--database', required=True)
     arg_parser.add_argument('--db_host', required=True)
     arg_parser.add_argument('--db_port', required=True)
     arg_parser.add_argument('--db_user', required=True)
@@ -18,7 +19,7 @@ if __name__ == '__main__':
     start_time = time.time()
     while (time.time() - start_time) < args.timeout:
         try:
-            conn = psycopg2.connect(user=args.db_user, host=args.db_host, port=args.db_port, password=args.db_password, dbname='postgres')
+            conn = psycopg2.connect(user=args.db_user, host=args.db_host, port=args.db_port, password=args.db_password, dbname=args.database)
             error = ''
             break
         except psycopg2.OperationalError as e:

--- a/17.0/entrypoint.sh
+++ b/17.0/entrypoint.sh
@@ -10,6 +10,7 @@ fi
 # and pass them as arguments to the odoo process if not present in the config file
 : ${HOST:=${DB_PORT_5432_TCP_ADDR:='db'}}
 : ${PORT:=${DB_PORT_5432_TCP_PORT:=5432}}
+: ${NAME:=${DB_ENV_POSTGRES_DB:=${POSTGRES_DB:='postgres'}}}
 : ${USER:=${DB_ENV_POSTGRES_USER:=${POSTGRES_USER:='odoo'}}}
 : ${PASSWORD:=${DB_ENV_POSTGRES_PASSWORD:=${POSTGRES_PASSWORD:='odoo'}}}
 
@@ -23,6 +24,7 @@ function check_config() {
     DB_ARGS+=("--${param}")
     DB_ARGS+=("${value}")
 }
+check_config "database" "$NAME"
 check_config "db_host" "$HOST"
 check_config "db_port" "$PORT"
 check_config "db_user" "$USER"

--- a/17.0/wait-for-psql.py
+++ b/17.0/wait-for-psql.py
@@ -7,6 +7,7 @@ import time
 
 if __name__ == '__main__':
     arg_parser = argparse.ArgumentParser()
+    arg_parser.add_argument('--database', required=True)
     arg_parser.add_argument('--db_host', required=True)
     arg_parser.add_argument('--db_port', required=True)
     arg_parser.add_argument('--db_user', required=True)
@@ -18,7 +19,7 @@ if __name__ == '__main__':
     start_time = time.time()
     while (time.time() - start_time) < args.timeout:
         try:
-            conn = psycopg2.connect(user=args.db_user, host=args.db_host, port=args.db_port, password=args.db_password, dbname='postgres')
+            conn = psycopg2.connect(user=args.db_user, host=args.db_host, port=args.db_port, password=args.db_password, dbname=args.database)
             error = ''
             break
         except psycopg2.OperationalError as e:


### PR DESCRIPTION
This allows the system administrator to set the standard PostgreSQL environment variable POSTGRES_DB to change the name of the database created by default.

Fixes #358.