### PR TITLE
Phase one of addressing exposed passwords.

### DIFF
--- a/15.0/odoo.conf
+++ b/15.0/odoo.conf
@@ -1,12 +1,16 @@
 [options]
 addons_path = /mnt/extra-addons
 data_dir = /var/lib/odoo
+db_name = postgress
+db_host = db
+db_port = 5432
+db_user = odoo
+db_password = odoo
+dbfilter = .*
 ; admin_passwd = admin
 ; csv_internal_sep = ,
 ; db_maxconn = 64
-; db_name = False
 ; db_template = template1
-; dbfilter = .*
 ; debug_mode = False
 ; email_from = False
 ; limit_memory_hard = 2684354560

--- a/16.0/odoo.conf
+++ b/16.0/odoo.conf
@@ -1,12 +1,16 @@
 [options]
 addons_path = /mnt/extra-addons
 data_dir = /var/lib/odoo
+db_name = postgress
+db_host = db
+db_port = 5432
+db_user = odoo
+db_password = odoo
+dbfilter = .*
 ; admin_passwd = admin
 ; csv_internal_sep = ,
 ; db_maxconn = 64
-; db_name = False
 ; db_template = template1
-; dbfilter = .*
 ; debug_mode = False
 ; email_from = False
 ; limit_memory_hard = 2684354560

--- a/17.0/odoo.conf
+++ b/17.0/odoo.conf
@@ -1,12 +1,16 @@
 [options]
 addons_path = /mnt/extra-addons
 data_dir = /var/lib/odoo
+db_name = postgress
+db_host = db
+db_port = 5432
+db_user = odoo
+db_password = odoo
+dbfilter = .*
 ; admin_passwd = admin
 ; csv_internal_sep = ,
 ; db_maxconn = 64
-; db_name = False
 ; db_template = template1
-; dbfilter = .*
 ; debug_mode = False
 ; email_from = False
 ; limit_memory_hard = 2684354560


### PR DESCRIPTION
## Phase one of addressing exposed passwords.

- For https://github.com/odoo/docker/issues/334
- Enable users to see what configuration settings they can/should set for databases
- Prepare for excluding the password from the command which is visible from the host machine.

## The problem
```
lathama@hostsystemnotthedockercontainer: $ ps ax | grep '/bin/odoo'
/usr/bin/python3 /usr/bin/odoo --db_host db --db_port 5432 --db_user odoo --db_password odoo
```

## The goal

```
lathama@hostsystemnotthedockercontainer: $ ps ax | grep '/bin/odoo'
/usr/bin/python3 /usr/bin/odoo
```

## Related

- https://github.com/odoo/docker/issues/343
- https://github.com/odoo/docker/issues/302
- https://github.com/odoo/docker/issues/265
- https://github.com/odoo/docker/issues/424