### PR TITLE
[IMP] Odoo 15.0-17.0: ensure the correct permissions for entrypoint

### DIFF
--- a/15.0/Dockerfile
+++ b/15.0/Dockerfile
@@ -67,6 +67,9 @@ RUN curl -o odoo.deb -sSL http://nightly.odoo.com/${ODOO_VERSION}/nightly/deb/od
 COPY ./entrypoint.sh /
 COPY ./odoo.conf /etc/odoo/
 
+# Ensure that entrypoint script has permissions to r/w/x for owner and group, and r/_/x for others
+RUN chmod 775 /entrypoint.sh
+
 # Set permissions and Mount /var/lib/odoo to allow restoring filestore and /mnt/extra-addons for users addons
 RUN chown odoo /etc/odoo/odoo.conf \
     && mkdir -p /mnt/extra-addons \

--- a/16.0/Dockerfile
+++ b/16.0/Dockerfile
@@ -81,6 +81,9 @@ RUN curl -o odoo.deb -sSL http://nightly.odoo.com/${ODOO_VERSION}/nightly/deb/od
 COPY ./entrypoint.sh /
 COPY ./odoo.conf /etc/odoo/
 
+# Ensure that entrypoint script has permissions to r/w/x for owner and group, and r/_/x for others
+RUN chmod 775 /entrypoint.sh
+
 # Set permissions and Mount /var/lib/odoo to allow restoring filestore and /mnt/extra-addons for users addons
 RUN chown odoo /etc/odoo/odoo.conf \
     && mkdir -p /mnt/extra-addons \

--- a/17.0/Dockerfile
+++ b/17.0/Dockerfile
@@ -83,6 +83,9 @@ RUN curl -o odoo.deb -sSL http://nightly.odoo.com/${ODOO_VERSION}/nightly/deb/od
 COPY ./entrypoint.sh /
 COPY ./odoo.conf /etc/odoo/
 
+# Ensure that entrypoint script has permissions to r/w/x for owner and group, and r/_/x for others
+RUN chmod 775 /entrypoint.sh
+
 # Set permissions and Mount /var/lib/odoo to allow restoring filestore and /mnt/extra-addons for users addons
 RUN chown odoo /etc/odoo/odoo.conf \
     && mkdir -p /mnt/extra-addons \


### PR DESCRIPTION
In some situations the entrypoint permissions can change while downloading or transferring the docker directory.
If file permissions change, it is very difficult to find out which permissions should be assigned to that file.
It can be a critical bug, and hard to fix as the entrypoint permissions differ from one app than another.
