### PR TITLE
Update Odoo 17 Dockerfile to use ODOO_RELEASE 20240905

### DIFF
--- a/17.0/Dockerfile
+++ b/17.0/Dockerfile
@@ -71,7 +71,7 @@ RUN npm install -g rtlcss
 
 # Install Odoo
 ENV ODOO_VERSION 17.0
-ARG ODOO_RELEASE=20240904
+ARG ODOO_RELEASE=20240905
 ARG ODOO_SHA=9fd807d55facb850ead1ad86dc628e26961dfb20
 RUN curl -o odoo.deb -sSL http://nightly.odoo.com/${ODOO_VERSION}/nightly/deb/odoo_${ODOO_VERSION}.${ODOO_RELEASE}_all.deb \
     && echo "${ODOO_SHA} odoo.deb" | sha1sum -c - \

--- a/17.0/Dockerfile
+++ b/17.0/Dockerfile
@@ -72,7 +72,7 @@ RUN npm install -g rtlcss
 # Install Odoo
 ENV ODOO_VERSION 17.0
 ARG ODOO_RELEASE=20240905
-ARG ODOO_SHA=9fd807d55facb850ead1ad86dc628e26961dfb20
+ARG ODOO_SHA=e183819cc8cc44a3db550929521ba68174859d9f
 RUN curl -o odoo.deb -sSL http://nightly.odoo.com/${ODOO_VERSION}/nightly/deb/odoo_${ODOO_VERSION}.${ODOO_RELEASE}_all.deb \
     && echo "${ODOO_SHA} odoo.deb" | sha1sum -c - \
     && apt-get update \


### PR DESCRIPTION
This pull request addresses issue:
https://github.com/odoo/docker/issues/517#issue-2513197399

When trying to use the latest version of the 17.0 branch in the Enterprise repository:

https://github.com/odoo/enterprise/tree/17.0

with the oficial odoo 17 docker image (https://hub.docker.com/_/odoo), the latest version, points to https://github.com/odoo/docker/blob/e0227fd3dce1da5abcd698f3fd805324c351d7c1/17.0/Dockerfile, which is up to date with master. 

The problem is that the odoo_17.0.20240904* release does not include the changes of commit: e8c088a pushed on 2024-09-04 (https://github.com/odoo/odoo/commit/e8c088a8bb87823bd1c42dc3394046231ad03116)

this comit is necesary for the latest enterpise version mensioned above.

The change: 
updates the Odoo 17 Dockerfile to use ODOO_RELEASE 20240905 instead of 20240904.

