### PR TITLE
Update wait-for-psql.py

### DIFF
--- a/15.0/wait-for-psql.py
+++ b/15.0/wait-for-psql.py
@@ -28,5 +28,5 @@ if __name__ == '__main__':
         time.sleep(1)
 
     if error:
-        print("Database connection failure: %s" % error, file=sys.stderr)
+        print(f"Database connection failure after {int(time.time() - start_time)} seconds: {error}", file=sys.stderr)
         sys.exit(1)


### PR DESCRIPTION
In your original code, the following line prints the error if the database connection fails:
print("Database connection failure: %s" % error, file=sys.stderr)
This simply displays the error message stored in the error variable, but it doesn't give any indication of how long the script attempted to connect to the database before failing.
print(f"Database connection failure after {int(time.time() - start_time)} seconds: {error}", file=sys.stderr)
