### PR TITLE
Fix keyserver error

### DIFF
--- a/16.0/Dockerfile
+++ b/16.0/Dockerfile
@@ -55,7 +55,7 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ bullseye-pgdg main' > /et
     && GNUPGHOME="$(mktemp -d)" \
     && export GNUPGHOME \
     && repokey='B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8' \
-    && gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "${repokey}" \
+    && gpg --batch --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys "${repokey}" \
     && gpg --batch --armor --export "${repokey}" > /etc/apt/trusted.gpg.d/pgdg.gpg.asc \
     && gpgconf --kill all \
     && rm -rf "$GNUPGHOME" \


### PR DESCRIPTION
Fix keyserver error for gpg

  53 |     # install latest postgresql-client
  54 | >>> RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ bullseye-pgdg main' > /etc/apt/sources.list.d/pgdg.list \
  55 | >>>     && GNUPGHOME="$(mktemp -d)" \
  56 | >>>     && export GNUPGHOME \
  57 | >>>     && repokey='B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8' \
  58 | >>>     && gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "${repokey}" \
  59 | >>>     && gpg --batch --armor --export "${repokey}" > /etc/apt/trusted.gpg.d/pgdg.gpg.asc \
  60 | >>>     && gpgconf --kill all \
  61 | >>>     && rm -rf "$GNUPGHOME" \
  62 | >>>     && apt-get update  \
  63 | >>>     && apt-get install --no-install-recommends -y postgresql-client \
  64 | >>>     && rm -f /etc/apt/sources.list.d/pgdg.list \
  65 | >>>     && rm -rf /var/lib/apt/lists/*
  66 |     
--------------------
ERROR: failed to solve: process "/bin/bash -xo pipefail -c echo 'deb http://apt.postgresql.org/pub/repos/apt/ bullseye-pgdg main' > /etc/apt/sources.list.d/pgdg.list     && GNUPGHOME=\"$(mktemp -d)\"     && export GNUPGHOME     && repokey='B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8'     && gpg --batch --keyserver keyserver.ubuntu.com --recv-keys \"${repokey}\"     && gpg --batch --armor --export \"${repokey}\" > /etc/apt/trusted.gpg.d/pgdg.gpg.asc     && gpgconf --kill all     && rm -rf \"$GNUPGHOME\"     && apt-get update      && apt-get install --no-install-recommends -y postgresql-client     && rm -f /etc/apt/sources.list.d/pgdg.list     && rm -rf /var/lib/apt/lists/*" did not complete successfully: exit code: 2