### PR TITLE
Add DATABASE environment variable

### DIFF
--- a/18.0/entrypoint.sh
+++ b/18.0/entrypoint.sh
@@ -12,21 +12,30 @@ fi
 : ${PORT:=${DB_PORT_5432_TCP_PORT:=5432}}
 : ${USER:=${DB_ENV_POSTGRES_USER:=${POSTGRES_USER:='odoo'}}}
 : ${PASSWORD:=${DB_ENV_POSTGRES_PASSWORD:=${POSTGRES_PASSWORD:='odoo'}}}
+: ${DATABASE:=${DB_ENV_POSTGRES_DATABASE:=${POSTGRES_DATABASE}}}
 
 DB_ARGS=()
 function check_config() {
     param="$1"
     value="$2"
-    if grep -q -E "^\s*\b${param}\b\s*=" "$ODOO_RC" ; then       
+
+    if grep -q -E "^\s*\b${param}\b\s*=" "$ODOO_RC" ; then
         value=$(grep -E "^\s*\b${param}\b\s*=" "$ODOO_RC" |cut -d " " -f3|sed 's/["\n\r]//g')
     fi;
+
+    if [[ "$param" == "database" && -z "$value" ]]; then
+        return
+    fi;
+
     DB_ARGS+=("--${param}")
     DB_ARGS+=("${value}")
 }
+
 check_config "db_host" "$HOST"
 check_config "db_port" "$PORT"
 check_config "db_user" "$USER"
 check_config "db_password" "$PASSWORD"
+check_config "database" "$DATABASE"
 
 case "$1" in
     -- | odoo)

--- a/18.0/wait-for-psql.py
+++ b/18.0/wait-for-psql.py
@@ -4,7 +4,6 @@ import psycopg2
 import sys
 import time
 
-
 if __name__ == '__main__':
     arg_parser = argparse.ArgumentParser()
     arg_parser.add_argument('--db_host', required=True)
@@ -17,24 +16,28 @@ if __name__ == '__main__':
     args = arg_parser.parse_args()
 
     start_time = time.time()
-    while (time.time() - start_time) < args.timeout:
-        try:
-            conn = psycopg2.connect(
-                user=args.db_user,
-                host=args.db_host,
-                port=args.db_port,
-                password=args.db_password,
-                dbname=args.database
-            )
+    database_list = args.database.split(',')
 
-            error = ''
-            break
-        except psycopg2.OperationalError as e:
-            error = e
-        else:
-            conn.close()
-        time.sleep(1)
+    for database in database_list:
+        while (time.time() - start_time) < args.timeout:
+            try:
+                conn = psycopg2.connect(
+                    user=args.db_user,
+                    host=args.db_host,
+                    port=args.db_port,
+                    password=args.db_password,
+                    dbname=database
+                )
 
-    if error:
-        print("Database connection failure: %s" % error, file=sys.stderr)
-        sys.exit(1)
+                error = ''
+                break
+            except psycopg2.OperationalError as e:
+                error = e
+            finally:
+                conn.close()
+
+            if error:
+                print("Database connection failure: %s" % error, file=sys.stderr)
+                sys.exit(1)
+
+            time.sleep(1)

--- a/18.0/wait-for-psql.py
+++ b/18.0/wait-for-psql.py
@@ -12,13 +12,21 @@ if __name__ == '__main__':
     arg_parser.add_argument('--db_user', required=True)
     arg_parser.add_argument('--db_password', required=True)
     arg_parser.add_argument('--timeout', type=int, default=5)
+    arg_parser.add_argument('--database', default='postgres', required=False)
 
     args = arg_parser.parse_args()
 
     start_time = time.time()
     while (time.time() - start_time) < args.timeout:
         try:
-            conn = psycopg2.connect(user=args.db_user, host=args.db_host, port=args.db_port, password=args.db_password, dbname='postgres')
+            conn = psycopg2.connect(
+                user=args.db_user,
+                host=args.db_host,
+                port=args.db_port,
+                password=args.db_password,
+                dbname=args.database
+            )
+
             error = ''
             break
         except psycopg2.OperationalError as e:


### PR DESCRIPTION
Per the discussion in this ticket:

https://github.com/odoo/docker/issues/535

This pull request adds support for a specific database while maintaining the original functionality if a database name is not specified or the database argument is blank. This addresses the concern that specifying a database name would lock Odoo to the `postgres` table

Add a `DATABASE=mydatabase` environment variable to select a specific database

Tests and examples here:
https://github.com/odoo/docker/issues/535#issuecomment-2646663645