### PR TITLE
install google-auth

### DIFF
--- a/17.0/Dockerfile
+++ b/17.0/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update && \
         libssl-dev \
         node-less \
         npm \
+        python3-google-auth \
         python3-magic \
         python3-num2words \
         python3-odf \

--- a/18.0/Dockerfile
+++ b/18.0/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update && \
         libssl-dev \
         node-less \
         npm \
+        python3-google-auth \
         python3-magic \
         python3-num2words \
         python3-odf \

--- a/19.0/Dockerfile
+++ b/19.0/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update && \
         libssl-dev \
         node-less \
         npm \
+        python3-google-auth \
         python3-magic \
         python3-num2words \
         python3-odf \


### PR DESCRIPTION
This fixes #442 since somehow google_auth is needed in `enterprise/social_push_notifications` and the whole Social module can't be installed without it.
<img width="1158" height="232" alt="2026-03-11-123221_1158x232_scrot" src="https://github.com/user-attachments/assets/e4312030-ffc7-4d1c-9db3-a4dd31df5326" />