### PR TITLE
Master env variables support moc

### DIFF
--- a/17.0/Dockerfile
+++ b/17.0/Dockerfile
@@ -1,10 +1,10 @@
 FROM ubuntu:jammy
-MAINTAINER Odoo S.A. <info@odoo.com>
+LABEL maintainer="Odoo S.A. <info@odoo.com>"
 
 SHELL ["/bin/bash", "-xo", "pipefail", "-c"]
 
 # Generate locale C.UTF-8 for postgres and general locale data
-ENV LANG en_US.UTF-8
+ENV LANG=en_US.UTF-8
 
 # Retrieve the target architecture to install the correct wkhtmltopdf package
 ARG TARGETARCH
@@ -70,7 +70,7 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ jammy-pgdg main' > /etc/a
 RUN npm install -g rtlcss
 
 # Install Odoo
-ENV ODOO_VERSION 17.0
+ENV ODOO_VERSION=17.0
 ARG ODOO_RELEASE=20260504
 ARG ODOO_SHA=43cb8f677cbb325ada98bdd10c5980386deb1a72
 RUN curl -o odoo.deb -sSL http://nightly.odoo.com/${ODOO_VERSION}/nightly/deb/odoo_${ODOO_VERSION}.${ODOO_RELEASE}_all.deb \
@@ -93,7 +93,7 @@ VOLUME ["/var/lib/odoo", "/mnt/extra-addons"]
 EXPOSE 8069 8071 8072
 
 # Set the default config file
-ENV ODOO_RC /etc/odoo/odoo.conf
+ENV ODOO_RC=/etc/odoo/odoo.conf
 
 COPY wait-for-psql.py /usr/local/bin/wait-for-psql.py
 

--- a/17.0/entrypoint.sh
+++ b/17.0/entrypoint.sh
@@ -8,20 +8,21 @@ fi
 
 # set the postgres database host, port, user and password according to the environment
 # and pass them as arguments to the odoo process if not present in the config file
-: ${HOST:=${DB_PORT_5432_TCP_ADDR:='db'}}
-: ${PORT:=${DB_PORT_5432_TCP_PORT:=5432}}
-: ${USER:=${DB_ENV_POSTGRES_USER:=${POSTGRES_USER:='odoo'}}}
-: ${PASSWORD:=${DB_ENV_POSTGRES_PASSWORD:=${POSTGRES_PASSWORD:='odoo'}}}
+: ${HOST:=${DB_PORT_5432_TCP_ADDR:=${PGHOST:='db'}}}
+: ${PORT:=${DB_PORT_5432_TCP_PORT:=${PGPORT:=5432}}}
+: ${USER:=${DB_ENV_POSTGRES_USER:=${POSTGRES_USER:=${PGUSER:='odoo'}}}}
+: ${PASSWORD:=${DB_ENV_POSTGRES_PASSWORD:=${POSTGRES_PASSWORD:=${PGPASSWORD:='odoo'}}}}
 
+# Unlike 19.0, Odoo 17/18 don't read PG* env vars natively,
+# so we always forward DB params as CLI args (unless set in odoo.conf).
 DB_ARGS=()
 function check_config() {
     param="$1"
     value="$2"
-    if grep -q -E "^\s*\b${param}\b\s*=" "$ODOO_RC" ; then       
-        value=$(grep -E "^\s*\b${param}\b\s*=" "$ODOO_RC" |cut -d " " -f3|sed 's/["\n\r]//g')
+    if ! grep -q -E "^\s*\b${param}\b\s*=" "$ODOO_RC" ; then
+        DB_ARGS+=("--${param}")
+        DB_ARGS+=("${value}")
     fi;
-    DB_ARGS+=("--${param}")
-    DB_ARGS+=("${value}")
 }
 check_config "db_host" "$HOST"
 check_config "db_port" "$PORT"

--- a/17.0/wait-for-psql.py
+++ b/17.0/wait-for-psql.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 import argparse
+import configparser
+import os
 import psycopg2
 import sys
 import time
@@ -7,18 +9,36 @@ import time
 
 if __name__ == '__main__':
     arg_parser = argparse.ArgumentParser()
-    arg_parser.add_argument('--db_host', required=True)
-    arg_parser.add_argument('--db_port', required=True)
-    arg_parser.add_argument('--db_user', required=True)
-    arg_parser.add_argument('--db_password', required=True)
+    arg_parser.add_argument('--db_host')
+    arg_parser.add_argument('--db_port')
+    arg_parser.add_argument('--db_user')
+    arg_parser.add_argument('--db_password')
     arg_parser.add_argument('--timeout', type=int, default=5)
 
     args = arg_parser.parse_args()
 
+    config_options = {}
+    rc_file_path = os.environ.get('ODOO_RC')
+    if rc_file_path:
+        config = configparser.RawConfigParser()
+        config.read(rc_file_path)
+        config_options = { k:v for k,v in config.items('options')}
+
+    db_host = config_options.get('db_host') or args.db_host or os.environ.get('PGHOST')
+    db_port = config_options.get('db_port') or args.db_port or os.environ.get('PGPORT')
+    db_user = config_options.get('db_user') or args.db_user or os.environ.get('PGUSER')
+    db_password = config_options.get('db_password') or args.db_password or os.environ.get('PGPASSWORD')
+
+    params = {'db_host': db_host, 'db_port': db_port, 'db_user': db_user, 'db_password': db_password}
+    missing_params = [k for k, v in params.items() if v is None]
+    if missing_params:
+        print(f"Missing required database parameters: {', '.join(missing_params)}", file=sys.stderr)
+        sys.exit(1)
+
     start_time = time.time()
     while (time.time() - start_time) < args.timeout:
         try:
-            conn = psycopg2.connect(user=args.db_user, host=args.db_host, port=args.db_port, password=args.db_password, dbname='postgres')
+            conn = psycopg2.connect(user=db_user, host=db_host, port=db_port, password=db_password, dbname='postgres')
             error = ''
             break
         except psycopg2.OperationalError as e:

--- a/18.0/Dockerfile
+++ b/18.0/Dockerfile
@@ -1,10 +1,10 @@
 FROM ubuntu:noble
-MAINTAINER Odoo S.A. <info@odoo.com>
+LABEL maintainer="Odoo S.A. <info@odoo.com>"
 
 SHELL ["/bin/bash", "-xo", "pipefail", "-c"]
 
 # Generate locale C.UTF-8 for postgres and general locale data
-ENV LANG en_US.UTF-8
+ENV LANG=en_US.UTF-8
 
 # Retrieve the target architecture to install the correct wkhtmltopdf package
 ARG TARGETARCH
@@ -70,7 +70,7 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ noble-pgdg main' > /etc/a
 RUN npm install -g rtlcss
 
 # Install Odoo
-ENV ODOO_VERSION 18.0
+ENV ODOO_VERSION=18.0
 ARG ODOO_RELEASE=20260504
 ARG ODOO_SHA=f3440ffc9a7be9be64d194419085aa624267f217
 RUN curl -o odoo.deb -sSL http://nightly.odoo.com/${ODOO_VERSION}/nightly/deb/odoo_${ODOO_VERSION}.${ODOO_RELEASE}_all.deb \
@@ -93,7 +93,7 @@ VOLUME ["/var/lib/odoo", "/mnt/extra-addons"]
 EXPOSE 8069 8071 8072
 
 # Set the default config file
-ENV ODOO_RC /etc/odoo/odoo.conf
+ENV ODOO_RC=/etc/odoo/odoo.conf
 
 COPY wait-for-psql.py /usr/local/bin/wait-for-psql.py
 

--- a/18.0/entrypoint.sh
+++ b/18.0/entrypoint.sh
@@ -8,20 +8,21 @@ fi
 
 # set the postgres database host, port, user and password according to the environment
 # and pass them as arguments to the odoo process if not present in the config file
-: ${HOST:=${DB_PORT_5432_TCP_ADDR:='db'}}
-: ${PORT:=${DB_PORT_5432_TCP_PORT:=5432}}
-: ${USER:=${DB_ENV_POSTGRES_USER:=${POSTGRES_USER:='odoo'}}}
-: ${PASSWORD:=${DB_ENV_POSTGRES_PASSWORD:=${POSTGRES_PASSWORD:='odoo'}}}
+: ${HOST:=${DB_PORT_5432_TCP_ADDR:=${PGHOST:='db'}}}
+: ${PORT:=${DB_PORT_5432_TCP_PORT:=${PGPORT:=5432}}}
+: ${USER:=${DB_ENV_POSTGRES_USER:=${POSTGRES_USER:=${PGUSER:='odoo'}}}}
+: ${PASSWORD:=${DB_ENV_POSTGRES_PASSWORD:=${POSTGRES_PASSWORD:=${PGPASSWORD:='odoo'}}}}
 
+# Unlike 19.0, Odoo 17/18 don't read PG* env vars natively,
+# so we always forward DB params as CLI args (unless set in odoo.conf).
 DB_ARGS=()
 function check_config() {
     param="$1"
     value="$2"
-    if grep -q -E "^\s*\b${param}\b\s*=" "$ODOO_RC" ; then       
-        value=$(grep -E "^\s*\b${param}\b\s*=" "$ODOO_RC" |cut -d " " -f3|sed 's/["\n\r]//g')
+    if ! grep -q -E "^\s*\b${param}\b\s*=" "$ODOO_RC" ; then
+        DB_ARGS+=("--${param}")
+        DB_ARGS+=("${value}")
     fi;
-    DB_ARGS+=("--${param}")
-    DB_ARGS+=("${value}")
 }
 check_config "db_host" "$HOST"
 check_config "db_port" "$PORT"

--- a/18.0/wait-for-psql.py
+++ b/18.0/wait-for-psql.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 import argparse
+import configparser
+import os
 import psycopg2
 import sys
 import time
@@ -7,18 +9,36 @@ import time
 
 if __name__ == '__main__':
     arg_parser = argparse.ArgumentParser()
-    arg_parser.add_argument('--db_host', required=True)
-    arg_parser.add_argument('--db_port', required=True)
-    arg_parser.add_argument('--db_user', required=True)
-    arg_parser.add_argument('--db_password', required=True)
+    arg_parser.add_argument('--db_host')
+    arg_parser.add_argument('--db_port')
+    arg_parser.add_argument('--db_user')
+    arg_parser.add_argument('--db_password')
     arg_parser.add_argument('--timeout', type=int, default=5)
 
     args = arg_parser.parse_args()
 
+    config_options = {}
+    rc_file_path = os.environ.get('ODOO_RC')
+    if rc_file_path:
+        config = configparser.RawConfigParser()
+        config.read(rc_file_path)
+        config_options = { k:v for k,v in config.items('options')}
+
+    db_host = config_options.get('db_host') or args.db_host or os.environ.get('PGHOST')
+    db_port = config_options.get('db_port') or args.db_port or os.environ.get('PGPORT')
+    db_user = config_options.get('db_user') or args.db_user or os.environ.get('PGUSER')
+    db_password = config_options.get('db_password') or args.db_password or os.environ.get('PGPASSWORD')
+
+    params = {'db_host': db_host, 'db_port': db_port, 'db_user': db_user, 'db_password': db_password}
+    missing_params = [k for k, v in params.items() if v is None]
+    if missing_params:
+        print(f"Missing required database parameters: {', '.join(missing_params)}", file=sys.stderr)
+        sys.exit(1)
+
     start_time = time.time()
     while (time.time() - start_time) < args.timeout:
         try:
-            conn = psycopg2.connect(user=args.db_user, host=args.db_host, port=args.db_port, password=args.db_password, dbname='postgres')
+            conn = psycopg2.connect(user=db_user, host=db_host, port=db_port, password=db_password, dbname='postgres')
             error = ''
             break
         except psycopg2.OperationalError as e:

--- a/19.0/Dockerfile
+++ b/19.0/Dockerfile
@@ -1,10 +1,10 @@
 FROM ubuntu:noble
-MAINTAINER Odoo S.A. <info@odoo.com>
+LABEL maintainer="Odoo S.A. <info@odoo.com>"
 
 SHELL ["/bin/bash", "-xo", "pipefail", "-c"]
 
 # Generate locale C.UTF-8 for postgres and general locale data
-ENV LANG en_US.UTF-8
+ENV LANG=en_US.UTF-8
 
 # Retrieve the target architecture to install the correct wkhtmltopdf package
 ARG TARGETARCH
@@ -70,7 +70,7 @@ RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ noble-pgdg main' > /etc/a
 RUN npm install -g rtlcss
 
 # Install Odoo
-ENV ODOO_VERSION 19.0
+ENV ODOO_VERSION=19.0
 ARG ODOO_RELEASE=20260504
 ARG ODOO_SHA=9e6a56cc743eba6f8f601e95531fb4bbb0937d6d
 RUN curl -o odoo.deb -sSL http://nightly.odoo.com/${ODOO_VERSION}/nightly/deb/odoo_${ODOO_VERSION}.${ODOO_RELEASE}_all.deb \
@@ -93,7 +93,7 @@ VOLUME ["/var/lib/odoo", "/mnt/extra-addons"]
 EXPOSE 8069 8071 8072
 
 # Set the default config file
-ENV ODOO_RC /etc/odoo/odoo.conf
+ENV ODOO_RC=/etc/odoo/odoo.conf
 
 COPY wait-for-psql.py /usr/local/bin/wait-for-psql.py
 

--- a/19.0/entrypoint.sh
+++ b/19.0/entrypoint.sh
@@ -17,16 +17,19 @@ DB_ARGS=()
 function check_config() {
     param="$1"
     value="$2"
-    if grep -q -E "^\s*\b${param}\b\s*=" "$ODOO_RC" ; then       
-        value=$(grep -E "^\s*\b${param}\b\s*=" "$ODOO_RC" |cut -d " " -f3|sed 's/["\n\r]//g')
+    pg_var="${3:-}"
+    if [ -n "$pg_var" ] && [[ -v "$pg_var" ]]; then
+        return
+    fi
+    if ! grep -q -E "^\s*\b${param}\b\s*=" "$ODOO_RC" ; then
+        DB_ARGS+=("--${param}")
+        DB_ARGS+=("${value}")
     fi;
-    DB_ARGS+=("--${param}")
-    DB_ARGS+=("${value}")
 }
-check_config "db_host" "$HOST"
-check_config "db_port" "$PORT"
-check_config "db_user" "$USER"
-check_config "db_password" "$PASSWORD"
+check_config "db_host" "$HOST" "PGHOST"
+check_config "db_port" "$PORT" "PGPORT"
+check_config "db_user" "$USER" "PGUSER"
+check_config "db_password" "$PASSWORD" "PGPASSWORD"
 
 case "$1" in
     -- | odoo)

--- a/19.0/wait-for-psql.py
+++ b/19.0/wait-for-psql.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 import argparse
+import configparser
+import os
 import psycopg2
 import sys
 import time
@@ -7,18 +9,36 @@ import time
 
 if __name__ == '__main__':
     arg_parser = argparse.ArgumentParser()
-    arg_parser.add_argument('--db_host', required=True)
-    arg_parser.add_argument('--db_port', required=True)
-    arg_parser.add_argument('--db_user', required=True)
-    arg_parser.add_argument('--db_password', required=True)
+    arg_parser.add_argument('--db_host')
+    arg_parser.add_argument('--db_port')
+    arg_parser.add_argument('--db_user')
+    arg_parser.add_argument('--db_password')
     arg_parser.add_argument('--timeout', type=int, default=5)
 
     args = arg_parser.parse_args()
 
+    config_options = {}
+    rc_file_path = os.environ.get('ODOO_RC')
+    if rc_file_path:
+        config = configparser.RawConfigParser()
+        config.read(rc_file_path)
+        config_options = { k:v for k,v in config.items('options')}
+
+    db_host = config_options.get('db_host') or args.db_host or os.environ.get('PGHOST')
+    db_port = config_options.get('db_port') or args.db_port or os.environ.get('PGPORT')
+    db_user = config_options.get('db_user') or args.db_user or os.environ.get('PGUSER')
+    db_password = config_options.get('db_password') or args.db_password or os.environ.get('PGPASSWORD')
+
+    params = {'db_host': db_host, 'db_port': db_port, 'db_user': db_user, 'db_password': db_password}
+    missing_params = [k for k, v in params.items() if v is None]
+    if missing_params:
+        print(f"Missing required database parameters: {', '.join(missing_params)}", file=sys.stderr)
+        sys.exit(1)
+
     start_time = time.time()
     while (time.time() - start_time) < args.timeout:
         try:
-            conn = psycopg2.connect(user=args.db_user, host=args.db_host, port=args.db_port, password=args.db_password, dbname='postgres')
+            conn = psycopg2.connect(user=db_user, host=db_host, port=db_port, password=db_password, dbname='postgres')
             error = ''
             break
         except psycopg2.OperationalError as e:


### PR DESCRIPTION
Since https://github.com/odoo/odoo/pull/207478, Odoo 19.0 properly handles the PostgreSQL
environment variables. This commit adds the same support to
`wait-for-psql.py`. While this feature was only introduced in Odoo 19.0,
it does no harm to support it in `wait-for-psql.py` across all versions.

While at it, the script can now also read the `odoo.conf file`, so it's
no longer necessary to pass command line arguments if their
configuration file counterparts already exist. The `entrypoint.sh` has
been adapted accordingly.

Also, fix various old warnings.